### PR TITLE
Update plugin dir references & ReadMe 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 Lightweight DITA for DITA-OT
 ============================
 
-DITA-OT LwDITA plug-in contains
+The DITA-OT LwDITA plug-in supersedes the previously released [Markdown plug-in for DITA-OT](https://github.com/jelovirt/dita-ot-markdown) and adds additional features to support Lightweight DITA. 
+
+It contains:
 
 -   a custom parser for Markdown and HTML to allow using
     MDITA and HDITA as a source document format,
@@ -58,7 +60,7 @@ Install
 
 The `dita` command line tool requires no additional configuration;
 running DITA-OT using Ant requires adding plug-in contributed JAR files
-to `CLASSPATH` with e.g. `-lib plugins/com.elovirta.dita.markdown`.
+to the `CLASSPATH` with e.g. `-lib plugins/org.lwdita`.
 
 Build
 -----

--- a/src/main/build-markdown_template.xml
+++ b/src/main/build-markdown_template.xml
@@ -10,7 +10,7 @@
     <condition property="markdown.type.prefix" value="_${markdown.type}" else="">
       <isset property="markdown.type"/>
     </condition>
-    <condition property="args.xsl" value="${dita.plugin.com.elovirta.dita.markdown.dir}/xsl/dita2markdown${markdown.type.prefix}.xsl">
+    <condition property="args.xsl" value="${dita.plugin.org.lwdita.dir}/xsl/dita2markdown${markdown.type.prefix}.xsl">
       <not>
         <isset property="args.xsl" />
       </not>
@@ -28,7 +28,7 @@
   </target>
 
   <target name="markdown_gitbook.init" depends="markdown_github.init">
-    <condition property="args.markdown.toc.xsl" value="${dita.plugin.com.elovirta.dita.markdown.dir}/xsl/map2markdown-cover_gitbook.xsl">
+    <condition property="args.markdown.toc.xsl" value="${dita.plugin.org.lwdita.dir}/xsl/map2markdown-cover_gitbook.xsl">
       <not>
         <isset property="args.markdown.toc.xsl" />
       </not>
@@ -60,7 +60,7 @@
   <target name="dita2markdown_gitbook" depends="markdown_gitbook.init, dita2markdown"/>
 
   <target name="dita.map.markdown.init" unless="noMap">
-    <condition property="args.markdown.toc.xsl" value="${dita.plugin.com.elovirta.dita.markdown.dir}/xsl/map2markdown-cover.xsl">
+    <condition property="args.markdown.toc.xsl" value="${dita.plugin.org.lwdita.dir}/xsl/map2markdown-cover.xsl">
       <not>
         <isset property="args.markdown.toc.xsl" />
       </not>


### PR DESCRIPTION
In the `2.0` release, Markdown outputs fail with references to the old plug-in directory name:

```
Error: stylesheet ~/[...]/dita-ot/src/main/${dita.plugin.com.elovirta.dita.markdown.dir}/xsl/dita2markdown.xsl doesn't exist.
```

This PR updates those to reflect the new `org.lwdita` name and revises the ReadMe to clarify the relationship to the deprecated `dita-ot-markdown` plug-in.