### PR TITLE
Update syntax reference link to org.lwdita

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The `format` attribute value must be set to `mdita` or `hdita` in order to
 recognize files as Markdown DITA or HTML DITA, respectively; the file extension is not used to
 recognize format.
 
-See [Syntax reference](https://github.com/jelovirt/dita-ot-markdown/wiki/Syntax-reference) for XML and Markdown DITA correspondence.
+See the [syntax reference](https://github.com/jelovirt/org.lwdita/wiki/Syntax-reference) for XML and Markdown DITA correspondence.
 
 ### Generating Markdown output
 


### PR DESCRIPTION
Just noticed that the syntax reference link still points to the archived predecessor repository at https://github.com/jelovirt/dita-ot-markdown and updated to refer to the current repo instead.

Not sure if the XML namespace declarations should also be adjusted, for example [utils.xsl#L4](https://github.com/jelovirt/org.lwdita/blob/master/src/main/resources/utils.xsl#L4) and several others.

Signed-off-by: Roger Sheen <roger@infotexture.net>.