### PR TITLE
Generate task labels

### DIFF
--- a/src/main/build-html_template.xml
+++ b/src/main/build-html_template.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:dita="http://dita-ot.sourceforge.net">
+<project xmlns:dita="http://dita-ot.sourceforge.net"
+         xmlns:if="ant:if">
 
   <target name="hdita.init">
     <condition property="out.ext" value=".md">
@@ -54,8 +55,8 @@
           includesfile="${dita.temp.dir}${file.separator}${user.input.file.listfile}"
           classpathref="dost.class.path"
           style="${args.hdita.toc.xsl}">
-      <excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"/>
-      <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
+      <excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if:set="resourceonlyfile"/>
+      <param name="OUTEXT" expression="${out.ext}" if:set="out.ext" />
       <dita:extension id="dita.conductor.hdita.toc.param" behavior="org.dita.dost.platform.InsertAction"/>
       <mapper type="glob"
               from="*${dita.input.filename}"
@@ -72,8 +73,8 @@
           includesfile="${dita.temp.dir}${file.separator}${user.input.file.listfile}"
           classpathref="dost.class.path"
           style="${args.hdita.toc.xsl}">
-      <excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"/>
-      <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
+      <excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if:set="resourceonlyfile"/>
+      <param name="OUTEXT" expression="${out.ext}" if:set="out.ext" />
       <dita:extension id="dita.conductor.hdita.toc.param" behavior="org.dita.dost.platform.InsertAction"/>
       <mapper type="glob"
               from="${user.input.file}"
@@ -92,22 +93,22 @@
           extension="${out.ext}" style="${args.xsl}"
           filenameparameter="FILENAME"
           filedirparameter="FILEDIR">
-      <excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"/>
+      <excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if:set="resourceonlyfile"/>
       <param name="TRANSTYPE" expression="${transtype}" />
-      <param name="FILTERFILE" expression="${dita.input.valfile.url}" if="dita.input.valfile" />
-      <param name="DRAFT" expression="${args.draft}" if="args.draft" />
-      <param name="ARTLBL" expression="${args.artlbl}" if="args.artlbl" />
-      <param name="GENERATE-TASK-LABELS" expression="${args.gen.task.lbl}" if="args.gen.task.lbl" />
-      <param name="PRESERVE-DITA-CLASS" expression="${args.hdita.classattr}" if="args.hdita.classattr"/>
-      <param name="NOPARENTLINK" expression="${args.hide.parent.link}" if="args.hide.parent.link"/>
+      <param name="FILTERFILE" expression="${dita.input.valfile.url}" if:set="dita.input.valfile" />
+      <param name="DRAFT" expression="${args.draft}" if:set="args.draft" />
+      <param name="ARTLBL" expression="${args.artlbl}" if:set="args.artlbl" />
+      <param name="GENERATE-TASK-LABELS" expression="${args.gen.task.lbl}" if:set="args.gen.task.lbl" />
+      <param name="PRESERVE-DITA-CLASS" expression="${args.hdita.classattr}" if:set="args.hdita.classattr"/>
+      <param name="NOPARENTLINK" expression="${args.hide.parent.link}" if:set="args.hide.parent.link"/>
   	  <param name="include.rellinks" expression="${include.rellinks}"/>
-      <param name="BREADCRUMBS" expression="${args.breadcrumbs}" if="args.breadcrumbs"/>
-      <param name="INDEXSHOW" expression="${args.indexshow}" if="args.indexshow" />
-      <param name="genDefMeta" expression="${args.gen.default.meta}" if="args.gen.default.meta" />
-      <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
+      <param name="BREADCRUMBS" expression="${args.breadcrumbs}" if:set="args.breadcrumbs"/>
+      <param name="INDEXSHOW" expression="${args.indexshow}" if:set="args.indexshow" />
+      <param name="genDefMeta" expression="${args.gen.default.meta}" if:set="args.gen.default.meta" />
+      <param name="OUTEXT" expression="${out.ext}" if:set="out.ext" />
       <param name="BASEDIR" expression="${basedir}"/>
       <param name="OUTPUTDIR" expression="${output.dir}"/>
-      <param name="DBG" expression="${args.debug}" if="args.debug"/>
+      <param name="DBG" expression="${args.debug}" if:set="args.debug"/>
       <!--dita:extension id="dita.conductor.hdita.param" behavior="org.dita.dost.platform.InsertAction"/-->
   	  <xmlcatalog refid="dita.catalog"/>
     </xslt>
@@ -124,22 +125,22 @@
           extension="${out.ext}" style="${args.xsl}"
           filenameparameter="FILENAME"
           filedirparameter="FILEDIR">
-    	<excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"/>
+    	<excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if:set="resourceonlyfile"/>
       <param name="TRANSTYPE" expression="${transtype}" />
-      <param name="FILTERFILE" expression="${dita.input.valfile.url}" if="dita.input.valfile" />
-      <param name="DRAFT" expression="${args.draft}" if="args.draft" />
-      <param name="ARTLBL" expression="${args.artlbl}" if="args.artlbl" />
-      <param name="GENERATE-TASK-LABELS" expression="${args.gen.task.lbl}" if="args.gen.task.lbl" />
-      <param name="PRESERVE-DITA-CLASS" expression="${args.hdita.classattr}" if="args.hdita.classattr"/>
-      <param name="NOPARENTLINK" expression="${args.hide.parent.link}" if="args.hide.parent.link"/>
+      <param name="FILTERFILE" expression="${dita.input.valfile.url}" if:set="dita.input.valfile" />
+      <param name="DRAFT" expression="${args.draft}" if:set="args.draft" />
+      <param name="ARTLBL" expression="${args.artlbl}" if:set="args.artlbl" />
+      <param name="GENERATE-TASK-LABELS" expression="${args.gen.task.lbl}" if:set="args.gen.task.lbl" />
+      <param name="PRESERVE-DITA-CLASS" expression="${args.hdita.classattr}" if:set="args.hdita.classattr"/>
+      <param name="NOPARENTLINK" expression="${args.hide.parent.link}" if:set="args.hide.parent.link"/>
       <param name="include.rellinks" expression="${include.rellinks}"/>
-      <param name="BREADCRUMBS" expression="${args.breadcrumbs}" if="args.breadcrumbs"/>
-      <param name="INDEXSHOW" expression="${args.indexshow}" if="args.indexshow" />
-      <param name="genDefMeta" expression="${args.gen.default.meta}" if="args.gen.default.meta" />
-      <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
+      <param name="BREADCRUMBS" expression="${args.breadcrumbs}" if:set="args.breadcrumbs"/>
+      <param name="INDEXSHOW" expression="${args.indexshow}" if:set="args.indexshow" />
+      <param name="genDefMeta" expression="${args.gen.default.meta}" if:set="args.gen.default.meta" />
+      <param name="OUTEXT" expression="${out.ext}" if:set="out.ext" />
       <param name="BASEDIR" expression="${basedir}"/>
       <param name="OUTPUTDIR" expression="${output.dir}"/>
-      <param name="DBG" expression="${args.debug}" if="args.debug"/>
+      <param name="DBG" expression="${args.debug}" if:set="args.debug"/>
       <!--dita:extension id="dita.conductor.hdita.param" behavior="org.dita.dost.platform.InsertAction"/-->
       <!--New,To generate&copy all dita files in the inputmap.dir, not all files in dita.temp.dir -->
       <mapper type="regexp"

--- a/src/main/build-markdown_template.xml
+++ b/src/main/build-markdown_template.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns:dita="http://dita-ot.sourceforge.net">
+<project xmlns:dita="http://dita-ot.sourceforge.net"
+         xmlns:if="ant:if">
 
   <target name="markdown.init">
     <condition property="out.ext" value=".md">
@@ -80,8 +81,8 @@
           includesfile="${dita.temp.dir}${file.separator}${user.input.file.listfile}"
           classpathref="dost.class.path"
           style="${args.markdown.toc.xsl}">
-      <excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"/>
-      <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
+      <excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if:set="resourceonlyfile"/>
+      <param name="OUTEXT" expression="${out.ext}" if:set="out.ext" />
       <dita:extension id="dita.conductor.markdown.toc.param" behavior="org.dita.dost.platform.InsertAction"/>
       <mapper type="glob"
               from="*${dita.input.filename}"
@@ -98,8 +99,8 @@
           includesfile="${dita.temp.dir}${file.separator}${user.input.file.listfile}"
           classpathref="dost.class.path"
           style="${args.markdown.toc.xsl}">
-      <excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"/>
-      <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
+      <excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if:set="resourceonlyfile"/>
+      <param name="OUTEXT" expression="${out.ext}" if:set="out.ext" />
       <dita:extension id="dita.conductor.markdown.toc.param" behavior="org.dita.dost.platform.InsertAction"/>
       <mapper type="glob"
               from="${user.input.file}"
@@ -114,26 +115,25 @@
     <xslt basedir="${dita.temp.dir}"
           destdir="${output.dir}" includesfile="${dita.temp.dir}${file.separator}${fullditatopicfile}"
           reloadstylesheet="${dita.markdown.reloadstylesheet}"
-          classpathref="dost.class.path"
           extension="${out.ext}" style="${args.xsl}"
           filenameparameter="FILENAME"
           filedirparameter="FILEDIR">
-      <excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"/>
+      <excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if:set="resourceonlyfile"/>
       <param name="TRANSTYPE" expression="${transtype}" />
-      <param name="FILTERFILE" expression="${dita.input.valfile.url}" if="dita.input.valfile" />
-      <param name="DRAFT" expression="${args.draft}" if="args.draft" />
-      <param name="ARTLBL" expression="${args.artlbl}" if="args.artlbl" />
-      <param name="GENERATE-TASK-LABELS" expression="${args.gen.task.lbl}" if="args.gen.task.lbl" />
-      <param name="PRESERVE-DITA-CLASS" expression="${args.markdown.classattr}" if="args.markdown.classattr"/>
-      <param name="NOPARENTLINK" expression="${args.hide.parent.link}" if="args.hide.parent.link"/>
+      <param name="FILTERFILE" expression="${dita.input.valfile.url}" if:set="dita.input.valfile" />
+      <param name="DRAFT" expression="${args.draft}" if:set="args.draft" />
+      <param name="ARTLBL" expression="${args.artlbl}" if:set="args.artlbl" />
+      <param name="GENERATE-TASK-LABELS" expression="${args.gen.task.lbl}" if:set="args.gen.task.lbl" />
+      <param name="PRESERVE-DITA-CLASS" expression="${args.markdown.classattr}" if:set="args.markdown.classattr"/>
+      <param name="NOPARENTLINK" expression="${args.hide.parent.link}" if:set="args.hide.parent.link"/>
   	  <param name="include.rellinks" expression="${include.rellinks}"/>
-      <param name="BREADCRUMBS" expression="${args.breadcrumbs}" if="args.breadcrumbs"/>
-      <param name="INDEXSHOW" expression="${args.indexshow}" if="args.indexshow" />
-      <param name="genDefMeta" expression="${args.gen.default.meta}" if="args.gen.default.meta" />
-      <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
+      <param name="BREADCRUMBS" expression="${args.breadcrumbs}" if:set="args.breadcrumbs"/>
+      <param name="INDEXSHOW" expression="${args.indexshow}" if:set="args.indexshow" />
+      <param name="genDefMeta" expression="${args.gen.default.meta}" if:set="args.gen.default.meta" />
+      <param name="OUTEXT" expression="${out.ext}" if:set="out.ext" />
       <param name="BASEDIR" expression="${basedir}"/>
       <param name="OUTPUTDIR" expression="${output.dir}"/>
-      <param name="DBG" expression="${args.debug}" if="args.debug"/>
+      <param name="DBG" expression="${args.debug}" if:set="args.debug"/>
       <!--dita:extension id="dita.conductor.markdown.param" behavior="org.dita.dost.platform.InsertAction"/-->
   	  <xmlcatalog refid="dita.catalog"/>
     </xslt>
@@ -146,26 +146,25 @@
     <xslt basedir="${dita.temp.dir}"
           destdir="${output.dir}" includesfile="${dita.temp.dir}${file.separator}${fullditatopicfile}"
           reloadstylesheet="${dita.markdown.reloadstylesheet}"
-          classpathref="dost.class.path"
           extension="${out.ext}" style="${args.xsl}"
           filenameparameter="FILENAME"
           filedirparameter="FILEDIR">
-    	<excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if="resourceonlyfile"/>
+    	<excludesfile name="${dita.temp.dir}${file.separator}${resourceonlyfile}" if:set="resourceonlyfile"/>
       <param name="TRANSTYPE" expression="${transtype}" />
-      <param name="FILTERFILE" expression="${dita.input.valfile.url}" if="dita.input.valfile" />
-      <param name="DRAFT" expression="${args.draft}" if="args.draft" />
-      <param name="ARTLBL" expression="${args.artlbl}" if="args.artlbl" />
-      <param name="GENERATE-TASK-LABELS" expression="${args.gen.task.lbl}" if="args.gen.task.lbl" />
-      <param name="PRESERVE-DITA-CLASS" expression="${args.markdown.classattr}" if="args.markdown.classattr"/>
-      <param name="NOPARENTLINK" expression="${args.hide.parent.link}" if="args.hide.parent.link"/>
+      <param name="FILTERFILE" expression="${dita.input.valfile.url}" if:set="dita.input.valfile" />
+      <param name="DRAFT" expression="${args.draft}" if:set="args.draft" />
+      <param name="ARTLBL" expression="${args.artlbl}" if:set="args.artlbl" />
+      <param name="GENERATE-TASK-LABELS" expression="${args.gen.task.lbl}" if:set="args.gen.task.lbl" />
+      <param name="PRESERVE-DITA-CLASS" expression="${args.markdown.classattr}" if:set="args.markdown.classattr"/>
+      <param name="NOPARENTLINK" expression="${args.hide.parent.link}" if:set="args.hide.parent.link"/>
       <param name="include.rellinks" expression="${include.rellinks}"/>
-      <param name="BREADCRUMBS" expression="${args.breadcrumbs}" if="args.breadcrumbs"/>
-      <param name="INDEXSHOW" expression="${args.indexshow}" if="args.indexshow" />
-      <param name="genDefMeta" expression="${args.gen.default.meta}" if="args.gen.default.meta" />
-      <param name="OUTEXT" expression="${out.ext}" if="out.ext" />
+      <param name="BREADCRUMBS" expression="${args.breadcrumbs}" if:set="args.breadcrumbs"/>
+      <param name="INDEXSHOW" expression="${args.indexshow}" if:set="args.indexshow" />
+      <param name="genDefMeta" expression="${args.gen.default.meta}" if:set="args.gen.default.meta" />
+      <param name="OUTEXT" expression="${out.ext}" if:set="out.ext" />
       <param name="BASEDIR" expression="${basedir}"/>
       <param name="OUTPUTDIR" expression="${output.dir}"/>
-      <param name="DBG" expression="${args.debug}" if="args.debug"/>
+      <param name="DBG" expression="${args.debug}" if:set="args.debug"/>
       <!--dita:extension id="dita.conductor.markdown.param" behavior="org.dita.dost.platform.InsertAction"/-->
       <!--New,To generate&copy all dita files in the inputmap.dir, not all files in dita.temp.dir -->
       <mapper type="regexp"

--- a/src/main/resources/dita2markdown_template.xsl
+++ b/src/main/resources/dita2markdown_template.xsl
@@ -9,6 +9,7 @@
   <xsl:import href="glossdisplay.xsl"/>
   <xsl:import href="taskdisplay.xsl"/>
   <xsl:import href="refdisplay.xsl"/-->
+  <xsl:import href="task.xsl"/>
   <xsl:import href="ut-d.xsl"/>
   <xsl:import href="sw-d.xsl"/>
   <xsl:import href="pr-d.xsl"/>

--- a/src/main/resources/task.xsl
+++ b/src/main/resources/task.xsl
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+This file is part of the DITA Open Toolkit project.
+
+Copyright 2016 Jarno Elovirta
+
+See the accompanying LICENSE file for applicable license.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:dita2html="http://dita-ot.sourceforge.net/ns/200801/dita2html"
+                version="2.0"
+                exclude-result-prefixes="xs dita2html">
+  
+  <xsl:param name="GENERATE-TASK-LABELS" select="'NO'"/>
+
+  <xsl:template match="*[contains(@class, ' task/steps ')]" name="task.steps">
+    <xsl:apply-templates select="." mode="generate-task-label">
+      <xsl:with-param name="use-label">
+        <xsl:call-template name="getVariable">
+          <xsl:with-param name="id" select="'task_procedure'"/>
+        </xsl:call-template>
+      </xsl:with-param>
+    </xsl:apply-templates>
+    <xsl:next-match/>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' task/steps-unordered ')]" name="task.steps-unordered">
+    <xsl:apply-templates select="." mode="generate-task-label">
+      <xsl:with-param name="use-label">
+        <xsl:call-template name="getVariable">
+          <xsl:with-param name="id" select="'task_procedure_unordered'"/>
+        </xsl:call-template>
+      </xsl:with-param>
+    </xsl:apply-templates>
+    <xsl:next-match/>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class,' task/prereq ')]" mode="dita2html:section-heading">
+    <xsl:apply-templates select="." mode="generate-task-label">
+      <xsl:with-param name="use-label">
+        <xsl:call-template name="getVariable">
+          <xsl:with-param name="id" select="'task_prereq'"/>
+        </xsl:call-template>
+      </xsl:with-param>
+    </xsl:apply-templates>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' task/context ')]" mode="dita2html:section-heading">
+    <xsl:apply-templates select="." mode="generate-task-label">
+      <xsl:with-param name="use-label">
+        <xsl:call-template name="getVariable">
+          <xsl:with-param name="id" select="'task_context'"/>
+        </xsl:call-template>
+      </xsl:with-param>
+    </xsl:apply-templates>
+  </xsl:template>
+      
+  <xsl:template match="*[contains(@class,' task/result ')]" mode="dita2html:section-heading">
+    <xsl:apply-templates select="." mode="generate-task-label">
+      <xsl:with-param name="use-label">
+        <xsl:call-template name="getVariable">
+          <xsl:with-param name="id" select="'task_results'"/>
+        </xsl:call-template>
+      </xsl:with-param>
+    </xsl:apply-templates>
+  </xsl:template>
+  
+  <xsl:template match="*[contains(@class,' task/postreq ')]" mode="dita2html:section-heading">
+    <xsl:apply-templates select="." mode="generate-task-label">
+      <xsl:with-param name="use-label">
+        <xsl:call-template name="getVariable">
+          <xsl:with-param name="id" select="'task_postreq'"/>
+        </xsl:call-template>
+      </xsl:with-param>
+    </xsl:apply-templates>
+  </xsl:template>
+  
+  <!--<xsl:template match="*[contains(@class,' task/taskbody ')]/*[contains(@class,' topic/example ')]">-->
+    <!--<section>-->
+      <!--<xsl:call-template name="commonattributes"/>-->
+      <!--<xsl:call-template name="gen-toc-id"/>-->
+      <!--<xsl:call-template name="setidaname"/>-->
+      <!--<xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>-->
+      <!--<xsl:apply-templates select="." mode="dita2html:section-heading"/>-->
+      <!--<xsl:apply-templates select="node() except *[contains(@class, ' topic/title ')]"/>-->
+      <!--<xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/>-->
+    <!--</section>-->
+  <!--</xsl:template>-->
+  
+  <xsl:template match="*[contains(@class,' task/taskbody ')]/*[contains(@class,' topic/example ')][not(*[contains(@class,' topic/title ')])]" mode="dita2html:section-heading">
+    <xsl:apply-templates select="." mode="generate-task-label">
+      <xsl:with-param name="use-label">
+        <xsl:call-template name="getVariable">
+          <xsl:with-param name="id" select="'task_example'"/>
+        </xsl:call-template>
+      </xsl:with-param>
+    </xsl:apply-templates>
+  </xsl:template>
+  
+  <xsl:template match="*" mode="generate-task-label">
+    <xsl:param name="use-label"/>
+    <xsl:param name="headLevel" as="xs:integer">
+      <xsl:variable name="headCount" select="count(ancestor::*[contains(@class, ' topic/topic ')]) + 1"/>
+      <xsl:choose>
+        <xsl:when test="$headCount > 6">6</xsl:when>
+        <xsl:otherwise><xsl:value-of select="$headCount"/></xsl:otherwise>
+      </xsl:choose>
+    </xsl:param>
+    <xsl:if test="$GENERATE-TASK-LABELS = 'YES'">
+      <header level="{$headLevel}">
+        <xsl:call-template name="commonattributes">
+          <xsl:with-param name="default-output-class" select="name(..)"/>
+        </xsl:call-template>
+        <xsl:value-of select="$use-label"/>
+      </header>
+    </xsl:if>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Generate task labels by `args.gen.task.lbl` property in Markdown output.

Fixes #41.