### PR TITLE
Update ast2markdown.xsl

### DIFF
--- a/src/main/resources/ast2markdown.xsl
+++ b/src/main/resources/ast2markdown.xsl
@@ -74,15 +74,28 @@
 
   <xsl:template match="li" mode="ast">
     <xsl:param name="indent" tunnel="yes" as="xs:string" select="''"/>
+    <xsl:variable name="leadingBlank" select="*[1][starts-with(.,' ')]"/>
     <xsl:value-of select="$indent"/>
     <xsl:choose>
       <xsl:when test="parent::bulletlist">
-        <xsl:text>-   </xsl:text>
+        <xsl:if test="not($leadingBlank)">
+          <xsl:text>- </xsl:text>		  
+        </xsl:if>
+        <xsl:if test="$leadingBlank">
+          <xsl:text>-</xsl:text>		  
+        </xsl:if>       
       </xsl:when>
       <xsl:otherwise>
-        <xsl:variable name="label" select="concat(position(), '.')" as="xs:string"/>
+        <xsl:variable name="label">
+          <xsl:if test="$leadingBlank">
+            <xsl:value-of select="concat(position(), '.')"/>
+          </xsl:if>
+          <xsl:if test="not($leadingBlank)">
+            <xsl:value-of select="concat(position(), '. ')"/>
+          </xsl:if>
+        </xsl:variable>
         <xsl:value-of select="$label"/>
-        <xsl:value-of select="substring($default-indent, string-length($label) + 1)"/>
+      <!-- <xsl:value-of select="substring($default-indent, string-length($label) + 1)"/> -->
       </xsl:otherwise>
     </xsl:choose>
     <xsl:apply-templates select="*[1]" mode="ast">
@@ -123,6 +136,10 @@
 
   <xsl:template match="codeblock" mode="ast">
     <xsl:param name="indent" tunnel="yes" as="xs:string" select="''"/>
+    <xsl:variable name="nested" select="ancestor::bulletlist or ancestor::orderedlist"/>
+    <xsl:if test="$nested">
+      <xsl:value-of select="$linefeed"/>
+    </xsl:if>
     <xsl:value-of select="$indent"/>
     <xsl:text>```</xsl:text>
     <xsl:choose>

--- a/src/test/resources/markdown/ast.md
+++ b/src/test/resources/markdown/ast.md
@@ -19,29 +19,30 @@ Asterisk \* bracket \[foo\].
 
 Hyphen:
 
--   hyphen list list list list list list list list list list list list list list list list list list list list list list list
--   list
-    -   item
-        -   four
-    -   fifth
-        -   sixth
+- hyphen list list list list list list list list list list list list list list list list list list list list list list list
+- list
+    - item
+        - four
+    - fifth
+        - sixth
 
 Asterix:
 
--   inline *bold* normal
-    -   inline
--   para
+- inline *bold* normal
+    - inline
+- para
 
-    -   inline
--   para
-
-    para
-
--   para
+    - inline
+- para
 
     para
 
--   para
+- para
+
+    para
+
+- para
+
 
     ```
     codeblock
@@ -49,21 +50,21 @@ Asterix:
     
     ```
 
-    -   para
+    - para
 
 Ordered:
 
-1.  ordered
-2.  list
-3.  item
-    1.  nested
-    2.  list
-4.  foo
-5.  foo
-6.  foo
-7.  foo
-8.  foo
-9.  foo
+1. ordered
+2. list
+3. item
+    1. nested
+    2. list
+4. foo
+5. foo
+6. foo
+7. foo
+8. foo
+9. foo
 10. foo
 11. foo
 12. foo
@@ -102,11 +103,11 @@ An inline ![Alt](test.jpg).
 
 ## Links {#links}
 
--   [Markdown](test.md.xml)
--   [DITA](topic.md.xml)
--   [HTML](test.html)
--   [External](http://www.example.com/test.html)
--   
+- [Markdown](test.md.xml)
+- [DITA](topic.md.xml)
+- [HTML](test.html)
+- [External](http://www.example.com/test.html)
+- 
 
 ## Tables {#tables}
 
@@ -136,10 +137,10 @@ Orange
 
 > This is email And so it this Again.
 
--   List
+- List
 
     > Quote in list
 
--   Second list
+- Second list
 
 


### PR DESCRIPTION
Proposed fix for issue https://github.com/jelovirt/org.lwdita/issues/46 Nested Lists not properly generated in output Markdown content when list Item starts with bold, italics, codeph...
The examples described in this issue demonstrate what this fix will do. Be aware that for all list items between "-" for unordered / "1." for ordered list and the following text of the list item in the future exactly one blank " " will be rendered to prevent that some following content is interpreted as codeblock.

Hint: Still an issue is that the code block of the first list item is not intended correctly. This I was not able to fix. The behaviuot and the details about this are described in issue https://github.com/jelovirt/org.lwdita/issues/48