### PR TITLE
Consume UTF-8 BOM from opened input stream

### DIFF
--- a/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
+++ b/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
@@ -1,6 +1,7 @@
 package com.elovirta.dita.markdown;
 
 import com.elovirta.dita.utils.ClasspathURIResolver;
+import com.google.common.annotations.VisibleForTesting;
 import com.vladsch.flexmark.ext.abbreviation.AbbreviationExtension;
 import com.vladsch.flexmark.ext.anchorlink.AnchorLinkExtension;
 import com.vladsch.flexmark.ext.autolink.AutolinkExtension;
@@ -192,7 +193,8 @@ public class MarkdownReader implements XMLReader {
         parse(new InputSource(systemId));
     }
 
-    private char[] getMarkdownContent(final InputSource input) throws IOException {
+    @VisibleForTesting
+    char[] getMarkdownContent(final InputSource input) throws IOException {
         final CharArrayWriter out = new CharArrayWriter();
         if (input.getByteStream() != null) {
             final String encoding = input.getEncoding() != null ? input.getEncoding() : "UTF-8";

--- a/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
+++ b/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
@@ -196,15 +196,11 @@ public class MarkdownReader implements XMLReader {
         final CharArrayWriter out = new CharArrayWriter();
         if (input.getByteStream() != null) {
             final String encoding = input.getEncoding() != null ? input.getEncoding() : "UTF-8";
-            final InputStream is = "UTF-8".equalsIgnoreCase(encoding)
+            try (InputStream is = "UTF-8".equalsIgnoreCase(encoding)
                     ? consumeBOM(input.getByteStream())
                     : input.getByteStream();
-            final Reader in = new InputStreamReader(is, encoding);
-            try {
+                 Reader in = new InputStreamReader(is, encoding)) {
                 copy(in, out);
-            } finally {
-                closeQuietly(in);
-                //closeQuietly(out);
             }
         } else if (input.getCharacterStream() != null) {
             final Reader in = input.getCharacterStream();
@@ -222,15 +218,11 @@ public class MarkdownReader implements XMLReader {
                 throw new IllegalArgumentException(e);
             }
             final String encoding = input.getEncoding() != null ? input.getEncoding() : "UTF-8";
-            final InputStream is = "UTF-8".equalsIgnoreCase(encoding)
+            try (InputStream is = "UTF-8".equalsIgnoreCase(encoding)
                     ? consumeBOM(inUrl.openStream())
                     : inUrl.openStream();
-            final Reader in = new InputStreamReader(is, encoding);
-            try {
+                 Reader in = new InputStreamReader(is, encoding)) {
                 copy(in, out);
-            } finally {
-                closeQuietly(in);
-                //closeQuietly(out);
             }
         }
         return out.toCharArray();
@@ -241,10 +233,9 @@ public class MarkdownReader implements XMLReader {
      *
      * @param in the original input stream
      * @return An input stream without a possible BOM
-     * @throws IOException
      */
     private InputStream consumeBOM(final InputStream in) throws IOException {
-        BufferedInputStream bin = new BufferedInputStream(in);
+        final BufferedInputStream bin = new BufferedInputStream(in);
         bin.mark(3);
         try {
             if (bin.read() != 0xEF || bin.read() != 0xBB || bin.read() != 0xBF) {

--- a/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
+++ b/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
@@ -247,9 +247,7 @@ public class MarkdownReader implements XMLReader {
         BufferedInputStream bin = new BufferedInputStream(in);
         bin.mark(3);
         try {
-            final byte[] buf = new byte[3];
-            bin.read(buf);
-            if (buf[0] != (byte) 0xEF || buf[1] != (byte) 0xBB || buf[2] != (byte) 0xBF) {
+            if (bin.read() != 0xEF || bin.read() != 0xBB || bin.read() != 0xBF) {
                 bin.reset();
             }
         } catch (final IOException e) {

--- a/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
+++ b/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
@@ -222,7 +222,10 @@ public class MarkdownReader implements XMLReader {
                 throw new IllegalArgumentException(e);
             }
             final String encoding = input.getEncoding() != null ? input.getEncoding() : "UTF-8";
-            final Reader in = new InputStreamReader(inUrl.openStream(), encoding);
+            final InputStream is = "UTF-8".equalsIgnoreCase(encoding)
+                    ? consumeBOM(inUrl.openStream())
+                    : inUrl.openStream();
+            final Reader in = new InputStreamReader(is, encoding);
             try {
                 copy(in, out);
             } finally {

--- a/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
@@ -3,7 +3,12 @@ package com.elovirta.dita.markdown;
 import com.elovirta.dita.utils.AbstractReaderTest;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.xml.sax.InputSource;
 import org.xml.sax.XMLReader;
+
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
 
 public class MarkdownReaderTest extends AbstractReaderTest {
 
@@ -139,6 +144,15 @@ public class MarkdownReaderTest extends AbstractReaderTest {
     @Test
     public void testBOM() throws Exception {
         run("testBOM.md");
+    }
+
+    @Test
+    public void getMarkdownContent_url() throws Exception {
+        final String input = getSrc() + "testBOM.md";
+        final URL in = getClass().getResource("/" + input);
+        final InputSource i = new InputSource(in.toString());
+        final char[] content = new MarkdownReader().getMarkdownContent(i);
+        assertEquals('W', content[0]);
     }
 
     @Test


### PR DESCRIPTION
Fix for #67, consume BOM even if input source does not have a byte stream and we need to open one ourselves.

Signed-off-by: Radu Coravu <radu_coravu@sync.ro>