### PR TITLE
Add shortdescs to format="markdown"

### DIFF
--- a/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
@@ -166,6 +166,11 @@ public class MarkdownReaderTest extends AbstractReaderTest {
     }
 
     @Test
+    public void testShortdescClass() throws Exception {
+        run("shortdesc_class.md");
+    }
+
+    @Test
     public void testLinebreak() throws Exception {
         run("linebreak.md");
     }

--- a/src/test/resources/dita/shortdesc_class.dita
+++ b/src/test/resources/dita/shortdesc_class.dita
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<topic id="shortdesc" class="- topic/topic ">
+  <title class="- topic/title ">Shortdesc</title>
+  <shortdesc class="- topic/shortdesc ">Shortdesc.</shortdesc>
+  <body class="- topic/body ">
+    <p class="- topic/p ">Paragraph.</p>
+  </body>
+</topic>

--- a/src/test/resources/lwdita/shortdesc_class.dita
+++ b/src/test/resources/lwdita/shortdesc_class.dita
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<topic id="shortdesc-shortdesc" class="- topic/topic ">
+  <title class="- topic/title ">Shortdesc {.shortdesc}</title>
+  <shortdesc class="- topic/shortdesc ">Shortdesc.</shortdesc>
+  <body class="- topic/body ">
+    <p class="- topic/p ">Paragraph.</p>
+  </body>
+</topic>

--- a/src/test/resources/markdown/shortdesc_class.md
+++ b/src/test/resources/markdown/shortdesc_class.md
@@ -1,0 +1,5 @@
+# Shortdesc {.shortdesc}
+
+Shortdesc.
+
+Paragraph.


### PR DESCRIPTION
I'm not sure if there is a reason this wasn't turned on for `markdown` format document, but I would find it very useful. At the moment, its the only reason to use `mdita` for me, and doing that loses the other extensions.