### PR TITLE
Processing subscript and superscript

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,4 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=8.0.322-tem
+gradle=5.5

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,14 @@ repositories {
 dependencies {
     compile group: "org.dita-ot", name: "dost", version: "[3.4,)"
     compile group: "com.vladsch.flexmark", name: "flexmark-all", version: "0.50.18"
+    compile group: 'commons-io', name: 'commons-io', version: '2.8.0'
+    compile(group: 'com.google.guava', name: 'guava', version: '25.1-jre') {
+        exclude group: 'org.checkerframework', module: 'checker-qual'
+        exclude group: 'org.codehaus.mojo', module: 'animal-sniffer-annotations'
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+        exclude group: 'com.google.j2objc', module: 'j2objc-annotations'
+    }
     compile group: 'nu.validator.htmlparser', name: 'htmlparser', version: '1.4'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'

--- a/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
+++ b/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
@@ -8,6 +8,7 @@ import com.vladsch.flexmark.ext.autolink.AutolinkExtension;
 import com.vladsch.flexmark.ext.definition.DefinitionExtension;
 import com.vladsch.flexmark.ext.footnotes.FootnoteExtension;
 import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughExtension;
+import com.vladsch.flexmark.ext.gfm.strikethrough.StrikethroughSubscriptExtension;
 import com.vladsch.flexmark.ext.ins.InsExtension;
 import com.vladsch.flexmark.ext.jekyll.tag.JekyllTagExtension;
 import com.vladsch.flexmark.ext.tables.TablesExtension;
@@ -80,7 +81,7 @@ public class MarkdownReader implements XMLReader {
                                 AutolinkExtension.create(),
                                 YamlFrontMatterExtension.create(),
                                 DefinitionExtension.create(),
-                                StrikethroughExtension.create()))
+                                StrikethroughSubscriptExtension.create()))
                         .set(DefinitionExtension.TILDE_MARKER, false)
                         // for full GFM table compatibility add the following table extension options:
                         .set(TablesExtension.COLUMN_SPANS, false)

--- a/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
@@ -86,6 +86,8 @@ public class CoreNodeRenderer extends SaxSerializer implements NodeRenderer {
     private static final Attributes DT_ATTS = buildAtts(TOPIC_DT);
     private static final Attributes DEL_ATTS = new AttributesBuilder().add(ATTRIBUTE_NAME_CLASS, TOPIC_PH.toString()).add("status", "deleted").build();
     private static final Attributes LINE_THROUGH_ATTS = buildAtts(HI_D_LINE_THROUGH);
+    private static final Attributes SUP_ATTS = buildAtts(HI_D_SUP);
+    private static final Attributes SUB_ATTS = buildAtts(HI_D_SUB);
     private static final Attributes TITLE_ATTS = buildAtts(TOPIC_TITLE);
     private static final Attributes SHORTDESC_ATTS = buildAtts(TOPIC_SHORTDESC);
     private static final Attributes PROLOG_ATTS = buildAtts(TOPIC_PROLOG);
@@ -481,11 +483,11 @@ public class CoreNodeRenderer extends SaxSerializer implements NodeRenderer {
     }
     
     private void render(final Superscript node, final NodeRendererContext context, final DitaWriter html) {
-      printTag(node, context, html, HI_D_SUP, EMPTY_ATTS);
+      printTag(node, context, html, HI_D_SUP, SUP_ATTS);
     }
     
     private void render(final Subscript node, final NodeRendererContext context, final DitaWriter html) {
-      printTag(node, context, html, HI_D_SUB, EMPTY_ATTS);
+      printTag(node, context, html, HI_D_SUB, SUB_ATTS);
     }
 
     private void writeImage(Image node, final String title, final String alt, final String url, final String key, final NodeRendererContext context, DitaWriter html) {

--- a/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
@@ -15,12 +15,14 @@ import com.vladsch.flexmark.ext.definition.DefinitionTerm;
 import com.vladsch.flexmark.ext.footnotes.Footnote;
 import com.vladsch.flexmark.ext.footnotes.FootnoteBlock;
 import com.vladsch.flexmark.ext.gfm.strikethrough.Strikethrough;
+import com.vladsch.flexmark.ext.gfm.strikethrough.Subscript;
 import com.vladsch.flexmark.ext.jekyll.tag.JekyllTag;
 import com.vladsch.flexmark.ext.jekyll.tag.JekyllTagBlock;
 import com.vladsch.flexmark.ext.tables.*;
 import com.vladsch.flexmark.ext.typographic.TypographicQuotes;
 import com.vladsch.flexmark.ext.yaml.front.matter.AbstractYamlFrontMatterVisitor;
 import com.vladsch.flexmark.ext.yaml.front.matter.YamlFrontMatterBlock;
+import com.vladsch.flexmark.superscript.Superscript;
 import com.vladsch.flexmark.util.ast.ContentNode;
 import com.vladsch.flexmark.util.ast.Document;
 import com.vladsch.flexmark.util.ast.Node;
@@ -223,7 +225,9 @@ public class CoreNodeRenderer extends SaxSerializer implements NodeRenderer {
                 new NodeRenderingHandler<ThematicBreak>(ThematicBreak.class, (node, context, html) -> render(node, context, html)),
                 new NodeRenderingHandler<AnchorLink>(AnchorLink.class, (node, context, html) -> render(node, context, html)),
                 new NodeRenderingHandler<JekyllTagBlock>(JekyllTagBlock.class, (node, context, html) -> render(node, context, html)),
-                new NodeRenderingHandler<JekyllTag>(JekyllTag.class, (node, context, html) -> render(node, context, html))
+                new NodeRenderingHandler<JekyllTag>(JekyllTag.class, (node, context, html) -> render(node, context, html)),
+                new NodeRenderingHandler<Superscript>(Superscript.class, (node, context, html) -> render(node, context, html)),
+                new NodeRenderingHandler<Subscript>(Subscript.class, (node, context, html) -> render(node, context, html))
         ));
     }
 
@@ -474,6 +478,14 @@ public class CoreNodeRenderer extends SaxSerializer implements NodeRenderer {
 
     private void render(final Image node, final NodeRendererContext context, final DitaWriter html) {
         writeImage(node, node.getTitle().toString(), null, node.getUrl().toString(), null, context, html);
+    }
+    
+    private void render(final Superscript node, final NodeRendererContext context, final DitaWriter html) {
+      printTag(node, context, html, HI_D_SUP, EMPTY_ATTS);
+    }
+    
+    private void render(final Subscript node, final NodeRendererContext context, final DitaWriter html) {
+      printTag(node, context, html, HI_D_SUB, EMPTY_ATTS);
     }
 
     private void writeImage(Image node, final String title, final String alt, final String url, final String key, final NodeRendererContext context, DitaWriter html) {

--- a/src/test/java/com/elovirta/dita/html/HDitaReaderTest.java
+++ b/src/test/java/com/elovirta/dita/html/HDitaReaderTest.java
@@ -12,6 +12,11 @@ public class HDitaReaderTest extends HtmlReaderTest {
     }
 
     @Override
+    public String getSrc() {
+        return "hdita/";
+    }
+
+    @Override
     public String getExp() {
         return "lwdita/";
     }

--- a/src/test/resources/dita/inline.dita
+++ b/src/test/resources/dita/inline.dita
@@ -13,6 +13,8 @@
     <p class="- topic/p ">here is a <b class="+ topic/ph hi-d/b ">bold</b> (<b class="+ topic/ph hi-d/b ">bold</b>) claim</p>
     <p class="- topic/p ">here is an <i class="+ topic/ph hi-d/i ">italics</i> (<i class="+ topic/ph hi-d/i ">italics</i>) claim</p>
     <p class="- topic/p ">here is <line-through class="+ topic/ph hi-d/line-through ">strike through</line-through> test</p>
+    <p class="- topic/p ">here is <sup class="+ topic/ph hi-d/sup ">super</sup> test</p>
+    <p class="- topic/p ">here is <sub class="+ topic/ph hi-d/sub ">sub</sub> test</p>
     <p class="- topic/p ">here is a <codeph class="+ topic/ph pr-d/codeph ">code</codeph> (<codeph class="+ topic/ph pr-d/codeph ">code</codeph>) claim</p>
     <p class="- topic/p ">here --- mdash --- dash</p>
     <p class="- topic/p ">here -- ndash -- dash</p>

--- a/src/test/resources/hdita/codeblock.html
+++ b/src/test/resources/hdita/codeblock.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>Test</title>
+<article>
+  <h1>Codeblock </h1>
+  <p>Code example on <code>for</code> loop:</p>
+  <pre><code>for i in items:
+      println(i)</code></pre>
+  <p>Fenced block:</p>
+  <pre id="foreach-example" class="scala"><code>items.foreach(println)</code></pre>
+</article>

--- a/src/test/resources/hdita/comment.html
+++ b/src/test/resources/hdita/comment.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>Comment</title>
+<article>
+  <h1>Comment</h1>
+
+    <p>Paragraph</p>
+    <p>Paragraph</p>
+
+</article>

--- a/src/test/resources/hdita/concept.html
+++ b/src/test/resources/hdita/concept.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<title>Concept</title>
+<article class="concept">
+  <h1>Concept</h1>
+  <p>This is a concept.</p>
+</article>

--- a/src/test/resources/hdita/conkeyref.html
+++ b/src/test/resources/hdita/conkeyref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>Conkeyref</title>
+<article>
+  <h1>Conkeyref</h1>
+  <p>shortdesc</p>
+  <p data-conkeyref="foo/bar">
+</article>

--- a/src/test/resources/hdita/conref.html
+++ b/src/test/resources/hdita/conref.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>Conref</title>
+<article>
+  <h1>Conref</h1>
+  <p>shortdesc</p>
+  <p data-conref="common.md#foo/bar"></p>
+</article>

--- a/src/test/resources/hdita/dl.html
+++ b/src/test/resources/hdita/dl.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<title>Definition list</title>
+<article>
+  <h1>Definition list</h1>
+  <dl>
+    <dt>Apple</dt>
+    <dd>Pomaceous fruit of plants of the genus Malus in
+      the family Rosaceae.</dd>
+    <dt>Orange Nested</dt>
+    <dd>The fruit of an evergreen tree of the genus Citrus.
+      <p>para</dd>
+  </dl>
+  <p>Break</p>
+  <dl>
+    <dt>Apple</dt>
+    <dd>Pomaceous fruit of plants of the genus Malus in
+      the family Rosaceae.</dd>
+    <dt>Orange Nested</dt>
+    <dd>The fruit of an evergreen tree of the genus Citrus.
+      <p>para</dd>
+  </dl>
+  <dl>
+    <dt>Apple</dt>
+    <dd>Pomaceous fruit of plants of the genus Malus in
+      the family Rosaceae.</dd>
+    <dt>Orange Nested</dt>
+    <dd>The fruit of an evergreen tree of the genus Citrus.
+      <p>para</dd>
+  </dl>
+</article>

--- a/src/test/resources/hdita/entity.html
+++ b/src/test/resources/hdita/entity.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<title>Entity&trade; title</title>
+<article id="entity-title">
+  <h1>Entity&trade; title</h1>
+  <p>Entity&trade;.</p>
+</article>

--- a/src/test/resources/hdita/escape.html
+++ b/src/test/resources/hdita/escape.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>Escape</title>
+<article>
+  <h1>Escape</h1>
+  <p>Asterisk * bracket [foo].</p>
+  <p>\`*_{}[]()&gt;#+-.!</p>
+</article>

--- a/src/test/resources/hdita/hdita.html
+++ b/src/test/resources/hdita/hdita.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<article data-hd-class="task">
+  <h1 id="how-to-do-something">How to do something</h1>
+  <p>Introduction to this specific task</p>
+  <section data-hd-class="task/context">
+    <p>Use only when ready</p>
+  </section>
+  <section data-hd-class="task/steps-informal">
+    <ol>
+      <li><p>Plan something</p></li>
+      <li><p>Do something</p></li>
+      <li><p>Evaluate something</p></li>
+    </ol>
+  </section>
+  <section data-hd-class="topic/example">
+    <p>Like this</p>
+  </section>
+</article>  

--- a/src/test/resources/hdita/header.html
+++ b/src/test/resources/hdita/header.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>A</title>
+<article>
+  <h1>A</h1>
+  <article>
+    <h2>A.1</h2>
+    <article>
+      <h3>A.1.a</h3>
+      <section><h4>A.1.a.I </h4>
+      </section>
+      <section id="example"><h4>A.1.a.II </h4>
+      </section>
+      <article>
+        <h4>A.1.a.III</h4>
+      </article>
+    </article>
+  </article>
+  <article>
+    <h2>A.2</h2>
+  </article>
+</article>

--- a/src/test/resources/hdita/header_attributes.html
+++ b/src/test/resources/hdita/header_attributes.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>My header</title>
+<article id="foo">
+  <h1>My header </h1>
+  <article id="foo-section">
+    <h2>My header ## </h2>
+  </article>
+  <article class="main shine" id="the-site">
+    <h2>My other header </h2>
+  </article>
+</article>

--- a/src/test/resources/hdita/html.html
+++ b/src/test/resources/hdita/html.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<title>HTML Block</title>
+<article>
+  <h1>HTML Block</h1>
+  <p>Plain paragraph.</p>
+  <p>HTML paragraph.</p>
+  <p><video controls poster="remote.png" src="remote.mp4"></video></p>
+</article>

--- a/src/test/resources/hdita/image.html
+++ b/src/test/resources/hdita/image.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<title>Images</title>
+<article>
+  <h1>Images</h1>
+  <p>An inline <img src="test.jpg" alt="Alt">.</p>
+  <img src="test.jpg" alt="Alt">
+  <figure>
+    <figcaption>Title</figcaption>
+    <img src="test.jpg" alt="Alt">
+  </figure>
+  <img keyref="image-key">
+  <figure>
+    <figcaption>Title</figcaption>
+    <img src="test.jpg" keyref="img_id" alt="Alt">
+  </figure>
+</article>

--- a/src/test/resources/hdita/inline.html
+++ b/src/test/resources/hdita/inline.html
@@ -9,7 +9,7 @@
   <p>here is an <i>italics</i> (<i>italics</i>) claim</p>
   <p>here is <s>strike through</s> test</p>
   <p>here is <sup>super</sup> test</p>
-  <p>here is <sub>sub</sub> test</p>
+  <p>here is ~sub~ test</p>
   <p>here is a <code>code</code> (<code>code</code>) claim</p>
   <p>here --- mdash --- dash</p>
   <p>here -- ndash -- dash</p>

--- a/src/test/resources/hdita/keyref.html
+++ b/src/test/resources/hdita/keyref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<title>Keyref</title>
+<article>
+  <h1>Keyref</h1>
+  <p>Foo <span data-keyref="bar"></span> baz.</p>
+</article>

--- a/src/test/resources/hdita/keys.html
+++ b/src/test/resources/hdita/keys.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Keys</title>
+<article>
+  <h1>Keys</h1>
+  <p>This is <a href="test.md">an example</a> reference-style link.</p>
+  <p>This is <a href="test.md">key-a</a> reference-style link.</p>
+  <p>This is <a href="test.md">Markdown</a> reference-style link.</p>
+  <p>This is <a href="test.md">Markdown</a> reference-style link.</p>
+  <p>This is <a keyref="key-missing">an example</a> reference-style link.</p>
+  <p>This is <a keyref="key-missing"></a> reference-style link.</p>
+</article>

--- a/src/test/resources/hdita/linebreak.html
+++ b/src/test/resources/hdita/linebreak.html
@@ -1,0 +1,6 @@
+﻿<!DOCTYPE html>
+<title>Line break</title>
+<article>
+  <h1>Line break</h1>
+  <p>Line<br>break.</p>
+</article>

--- a/src/test/resources/hdita/link.html
+++ b/src/test/resources/hdita/link.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<title>Links</title>
+<article>
+  <h1>Links</h1>
+  <p>
+    <a href="concept.md">Markdown</a>
+  </p>
+  <p>
+    <a href="concept.md#id">Markdown with fragment</a>
+  </p>
+  <p>
+    <a href="topic.dita">DITA</a>
+  </p>
+  <p>
+    <a href="test.html">HTML</a>
+  </p>
+  <p>
+    <a href="/api">Relative</a>
+  </p>
+  <p>
+    <a href="http://www.example.com/test.html">External</a>
+  </p>
+  <p>
+    <a data-keyref="key"></a>
+  </p>
+  <p>
+    <a href="mailto:address@example.com"></a>
+  </p>
+  <p>
+    <a href="http://www.example.com/">http://www.example.com/</a>
+  </p>
+  <p>http://www.example.com/</p>
+</article>

--- a/src/test/resources/hdita/multiple_top_level.html
+++ b/src/test/resources/hdita/multiple_top_level.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<title>Heading A</title>
+<article id="heading-a">
+  <h1>Heading A</h1>
+  <p>Content A.</p>
+  <section id="heading-a1">
+    <h2>Heading A.1</h2>
+    <p>Content A.1.</p>
+  </section>
+</article>
+<article id="heading-b">
+  <h1>Heading B</h1>
+  <p>Content B.</p>
+  <section id="heading-b1">
+    <h2>Heading B.1</h2>
+    <p>Content B.1.</p>
+  </section>
+</article>

--- a/src/test/resources/hdita/multiple_top_level_specialized.html
+++ b/src/test/resources/hdita/multiple_top_level_specialized.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<title>Concept</title>
+<article id="concept" class="concept">
+  <h1>Concept </h1>
+  <p>Content A.</p>
+  <article id="heading-a1">
+    <h2>Heading A.1</h2>
+    <p>Content A.1.</p>
+  </article>
+</article>
+<article id="task" class="task">
+  <h1>Task </h1>
+  <section><p>Content B.</p></section>
+  <article id="heading-b1">
+    <h2>Heading B.1</h2>
+    <section><p>Content B.1.</p></section>
+  </article>
+</article>
+<article id="reference" class="reference">
+  <h1>Reference </h1>
+  <section><p>Content C.</p></section>
+  <article id="heading-c1">
+    <h2>Heading C.1</h2>
+    <section><p>Content C.1.</p></section>
+  </article>
+</article>
+<article id="topic">
+  <h1>Topic</h1>
+  <p>Content D.</p>
+  <article id="heading-d1">
+    <h2>Heading D.1</h2>
+    <p>Content D.1.</p>
+  </article>
+</article>

--- a/src/test/resources/hdita/ol.html
+++ b/src/test/resources/hdita/ol.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<title>Numbered list</title>
+<article>
+  <h1>Numbered list</h1>
+
+    <p>Ordered:</p>
+    <ol>
+      <li>
+        <p>ordered</p>
+      </li>
+      <li>
+        <p>list</p>
+      </li>
+      <li>
+        <p>item</p>
+        <ol>
+          <li>
+            <p>nested</p>
+          </li>
+          <li>
+            <p>list</p>
+          </li>
+        </ol>
+      </li>
+      <li>
+        <p>foo</p>
+      </li>
+      <li>
+        <p>foo</p>
+      </li>
+      <li>
+        <p>foo</p>
+      </li>
+      <li>
+        <p>foo</p>
+      </li>
+      <li>
+        <p>foo</p>
+      </li>
+      <li>
+        <p>foo</p>
+      </li>
+      <li>
+        <p>foo</p>
+      </li>
+      <li>
+        <p>foo</p>
+      </li>
+      <li>
+        <p>foo</p>
+      </li>
+      <li>
+        <p>foo</p>
+      </li>
+      <li>
+        <p>foo</p>
+      </li>
+      <li>
+        <p>foo</p>
+      </li>
+    </ol>
+
+</article>

--- a/src/test/resources/hdita/pandoc_header.html
+++ b/src/test/resources/hdita/pandoc_header.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<title>Root</title>
+<article>
+<article class="nested0" id="root">
+  <h1> Root</h1>
+  <article class="nested1" id="a">
+    <h2>A</h2>
+
+    <article class="nested2" id="a-1">
+      <h3>A.1</h3>
+
+      <article class="nested3" id="a-1-a">
+        <h4>A.1.a</h4>
+
+        <article class="nested4" id="a-1-a_i">
+          <h5>A.1.a.I</h5>
+
+        </article>
+      </article>
+    </article>
+    <article class="nested2" id="a-2">
+      <h3>A.2</h3>
+
+    </article>
+  </article>
+  <article class="nested1" id="b">
+    <h2>B</h2>
+
+    <article class="nested2" id="b-1">
+      <h3>B.1</h3>
+
+    </article>
+  </article>
+</article>
+</article>

--- a/src/test/resources/hdita/quote.html
+++ b/src/test/resources/hdita/quote.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Quote</title>
+<article>
+  <h1>Quote</h1>
+  <lq>
+    <p>This is email And so it this</p>
+    <p>Again.</p>
+  </lq>
+  <ul>
+    <li>
+      <p>List</p>
+      <lq>
+        <p>Quote in list</p>
+      </lq>
+    </li>
+    <li>
+      <p>Second list</p>
+    </li>
+  </ul>
+</article>

--- a/src/test/resources/hdita/reference.html
+++ b/src/test/resources/hdita/reference.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<title>Reference</title>
+<article class="reference">
+  <h1>Reference</h1>
+  <!--section class="section"-->
+    <p>This is reference.</p>
+  <!--/section-->
+</article>

--- a/src/test/resources/hdita/short.html
+++ b/src/test/resources/hdita/short.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<title>x</title>
+<article>
+  <h1>x</h1>
+</article>

--- a/src/test/resources/hdita/shortdesc.html
+++ b/src/test/resources/hdita/shortdesc.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>Shortdesc</title>
+<article>
+  <h1>Shortdesc</h1>
+
+    <p>Shortdesc.</p>
+    <p>Paragraph.</p>
+
+</article>

--- a/src/test/resources/hdita/table.html
+++ b/src/test/resources/hdita/table.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<title>Tables</title>
+<article>
+  <h1>Tables</h1>
+  <table>
+    <colgroup>
+      <col>
+      <col>
+      <col>
+      <col>
+    </colgroup>
+    <thead>
+    <tr>
+      <th align="right">Right</th>
+      <th align="left">Left</th>
+      <th>Default</th>
+      <th align="center">Center</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td align="right">12</td>
+      <td align="left">12</td>
+      <td>12</td>
+      <td align="center">12</td>
+    </tr>
+    <tr>
+      <td align="right">123</td>
+      <td align="left">123</td>
+      <td>123</td>
+      <td align="center">123</td>
+    </tr>
+    <tr>
+      <td align="right">1</td>
+      <td align="left">1</td>
+      <td>1</td>
+      <td align="center">1</td>
+    </tr>
+    </tbody>
+  </table>
+  <p>PHP Table:</p>
+  <table>
+    <colgroup>
+      <col>
+      <col>
+      <col>
+    </colgroup>
+    <thead>
+    <tr>
+      <th align="left">First Header</th>
+      <th align="center">Second Header Very long data entry Very long data entry Very long
+        data entry Very long data entry Very long data entry Very long data entry Very long data entry Very long data
+        entry Very long data entry
+      </th>
+      <th align="right">Third Header</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td align="left">First row</td>
+      <td align="center">Data</td>
+      <td align="right">Very long data entry Very long data entry Very long data
+        entry Very long data entry Very long data entry Very long data entry Very long data entry Very long data entry
+        Very long data entry Very long data entry
+      </td>
+    </tr>
+    <tr>
+      <td align="left">Second row</td>
+      <td align="center">
+        <strong>Cell</strong>
+      </td>
+      <td align="right">
+        <em>Cell</em>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+</article>

--- a/src/test/resources/hdita/task.html
+++ b/src/test/resources/hdita/task.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<title>Task</title>
+<article class="task">
+  <h1>Task</h1>
+  <!--section class="section"-->
+    <p>Context</p>
+  <!--/section-->
+  <ol>
+    <li>
+      <p>Command</p>
+      <p>Info.</p>
+    </li>
+    <li>
+      <p><strong>Command</strong></p>
+      <p>Info.</p>
+    </li>
+    <li>
+      <p><strong>Command</strong> tail</p>
+      <p>Info.</p>
+    </li>
+    <li>
+      <p>head <strong>Command</strong></p>
+      <p>Info.</p>
+    </li>
+    <li>
+      <p>head <strong>Command</strong> tail</p>
+      <p>Info.</p>
+    </li>
+    <li>
+      <p>Command</p>
+    </li>
+    <li>
+      <p><strong>Command</strong></p>
+    </li>
+    <li>
+      <p><strong>Command</strong> tail</p>
+    </li>
+    <li>
+      <p>head <strong>Command</strong></p>
+    </li>
+    <li>
+      <p>head <strong>Command</strong> tail</p>
+    </li>
+  </ol>
+</article>

--- a/src/test/resources/hdita/taskOneStep.html
+++ b/src/test/resources/hdita/taskOneStep.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>Task</title>
+<article class="task">
+  <h1>Task</h1>
+  <!--section class="section"-->
+    <p>Context</p>
+  <!--/section-->
+  <ol>
+    <li>
+      <p>Command</p>
+      <p>Info.</p>
+    </li>
+  </ol>
+</article>

--- a/src/test/resources/hdita/test.html
+++ b/src/test/resources/hdita/test.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Test</title>
+  </head>
+  <body>
+    <article>
+      <h1 id="test">Test</h1>
+      <p>Paragraph <s>Text</s> <em>test</em> and <strong>list</strong>:</p>
+      <ul>
+        <li><p>hyphen</p></li>
+        <li><p>list</p></li>
+        <li><p>item</p></li>
+      </ul>
+      <ul>
+        <li>
+          <p>asterix</p>
+          <ul>
+            <li><p>list</p></li>
+          </ul>
+        </li>
+        <li><p>item</p>
+          <ul>
+            <li><p>nested</p></li>
+          </ul>
+        </li>
+      </ul>
+      <ol>
+        <li><p>ordered</p></li>
+        <li><p>list</p></li>
+        <li><p>item</p>
+          <ol>
+            <li><p>nested</p></li>
+            <li><p>list</p></li>
+          </ol>
+        </li>
+      </ol>
+      <section id="codeblock-section">
+        <h2>Codeblock {.section}</h2>
+        <p>Code example on <code>for</code> loop:</p>
+        <pre><code>for i in items:
+            println(i)</code></pre>
+        <p>Fenced block:</p>
+        <pre id="foreach-example" class="scala"><code>items.foreach(println)</code></pre>
+      </section>
+      <section id="tables">
+        <h2>Tables</h2>
+        <table>
+          <caption>simple_table</caption>
+          <thead>
+          <tr>
+            <th align="left">First Header</th>
+            <th align="center">Second Header</th>
+            <th align="right">Third Header</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td align="left">First row</td>
+            <td align="center">Data</td>
+            <td align="right">Very long data entry</td>
+          </tr>
+          <tr>
+            <td align="left">Second row</td>
+            <td align="center"><strong>Cell</strong></td>
+            <td align="right"><em>Cell</em></td>
+          </tr>
+          </tbody>
+        </table>
+        <table>
+          <caption>Prototype table][reference_table</caption>
+          <thead>
+          <tr>
+            <th></th>
+            <th align="center">Grouping</th>
+            <th align="right"></th>
+          </tr>
+          <tr>
+            <th>First Header</th>
+            <th align="center">Second Header</th>
+            <th align="right">Third Header</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td>Content</td>
+            <td align="center"><em>Long Cell</em></td>
+            <td align="right"></td>
+          </tr>
+          <tr>
+            <td>Content</td>
+            <td align="center"><strong>Cell</strong></td>
+            <td align="right">Cell</td>
+          </tr>
+          <tr>
+            <td>New section</td>
+            <td align="center">More</td>
+            <td align="right">Data</td>
+          </tr>
+          </tbody>
+        </table>
+      </section>
+      <section id="links">
+        <h2>Links</h2>
+        <ul>
+          <li>
+            <p><a href="test.md">Markdown</a></p>
+          </li>
+          <li>
+            <p><a href="test.dita">DITA</a></p>
+          </li>
+          <li>
+            <p><a href="test.html">HTML</a></p>
+          </li>
+          <li>
+            <p><a href="http://www.example.com/test.html">External</a></p>
+          </li>
+        </ul>
+      </section>
+      <section id="keys">
+        <h2>Keys</h2>
+        <p>This is <a href="test.md">an example</a> reference-style link.</p>
+        <p>This is <a href="test.md">key-a</a> reference-style link.</p>
+        <p>This is <a href="test.md">Markdown</a> reference-style link.</p>
+        <p>This is <a href="test.md">Markdown</a> reference-style link.</p>
+        <p>This is <a data-keyref="key-missing">an example</a> reference-style link.</p>
+        <p>This is <a data-keyref="key-missing"></a> reference-style link.</p>
+      </section>
+    </article>
+  </body>
+</html>

--- a/src/test/resources/hdita/topic.html
+++ b/src/test/resources/hdita/topic.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<title>Topic</title>
+<article>
+  <h1>Topic</h1>
+</article>

--- a/src/test/resources/hdita/ul.html
+++ b/src/test/resources/hdita/ul.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<title>Bullet list</title>
+<article>
+  <h1>Bullet list</h1>
+  <p>Hyphen:</p>
+  <ul>
+    <li>
+      <p>hyphen list list list list list list list list list list list list
+        list list list list list list list list list list list</p>
+    </li>
+    <li>
+      <p>list</p>
+      <ul>
+        <li>
+          <p>item</p>
+          <ul>
+            <li>
+              <p>four</p>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <p>fifth</p>
+          <ul>
+            <li>
+              <p>sixth</p>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+  </ul>
+  <p>Asterix:</p>
+  <ul>
+    <li>
+      <p>inline <em>bold</em> normal</p>
+      <ul>
+        <li>
+          <p>inline</p>
+        </li>
+      </ul>
+    </li>
+    <li>
+      <p>para</p>
+      <ul>
+        <li>
+          <p>inline</p>
+        </li>
+      </ul>
+    </li>
+    <li>
+      <p>para</p>
+      <p>para</p>
+    </li>
+    <li>
+      <p>para</p>
+      <p>para</p>
+      <ul>
+        <li>
+          <p>below this will not work</p>
+        </li>
+      </ul>
+    </li>
+    <li>
+      <p>para</p>
+      <ul>
+        <li>
+          <p>para</p>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</article>

--- a/src/test/resources/hdita/yaml.html
+++ b/src/test/resources/hdita/yaml.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<title>YAML Header</title>
+<article>
+  <h1>YAML Header</h1>
+  
+
+</article>

--- a/src/test/resources/lwdita/inline.dita
+++ b/src/test/resources/lwdita/inline.dita
@@ -17,6 +17,8 @@
     <p class="- topic/p ">here is an <i class="+ topic/ph hi-d/i ">italics</i> (<i
         class="+ topic/ph hi-d/i ">italics</i>) claim</p>
     <p class="- topic/p ">here is <line-through class="+ topic/ph hi-d/line-through ">strike through</line-through> test</p>
+    <p class="- topic/p ">here is <sup class="+ topic/ph hi-d/sup ">super</sup> test</p>
+    <p class="- topic/p ">here is ~sub~ test</p>
     <p class="- topic/p ">here is a <codeph class="+ topic/ph pr-d/codeph ">code</codeph> (<codeph
       class="+ topic/ph pr-d/codeph ">code</codeph>) claim</p>
     <p class="- topic/p ">here --- mdash --- dash</p>

--- a/src/test/resources/markdown/inline.md
+++ b/src/test/resources/markdown/inline.md
@@ -11,6 +11,10 @@ here is an *italics* (*italics*) claim
 
 here is ~~strike through~~ test
 
+here is ^super^ test
+
+here is ~sub~ test
+
 here is a `code` (`code`) claim
 
 here --- mdash --- dash


### PR DESCRIPTION
I added 2 new handlers for processing subscript and superscript (#7).

Now, a markdown like this:
 `Text ^super^ ~sub~`
will be converted in:
`<p>Text <sup>super</sup> <sub>sub</sub></p>`