### PR TITLE
Backslash from code phrase is removed

### DIFF
--- a/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
@@ -1367,11 +1367,18 @@ public class CoreNodeRenderer extends SaxSerializer implements NodeRenderer {
 //    }
 
     private void render(final Text node, final NodeRendererContext context, final DitaWriter html) {
-        if (abbreviations.isEmpty()) {
-            html.characters(node.getChars().unescapeNoEntities());
+      if (abbreviations.isEmpty()) {
+        boolean shoudUnescape = ! (node.getParent() instanceof Code);
+        String content;
+        if(shoudUnescape) {
+          content = node.getChars().unescapeNoEntities();
         } else {
-            printWithAbbreviations(node.getChars().toString(), html);
+          content = node.getChars().toString();
         }
+        html.characters(content);
+      } else {
+        printWithAbbreviations(node.getChars().toString(), html);
+      }
     }
 
 //    @Override

--- a/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
@@ -1367,18 +1367,15 @@ public class CoreNodeRenderer extends SaxSerializer implements NodeRenderer {
 //    }
 
     private void render(final Text node, final NodeRendererContext context, final DitaWriter html) {
-      if (abbreviations.isEmpty()) {
-        boolean shoudUnescape = ! (node.getParent() instanceof Code);
-        String content;
-        if(shoudUnescape) {
-          content = node.getChars().unescapeNoEntities();
+        if (abbreviations.isEmpty()) {
+            if (node.getParent() instanceof Code) {
+                html.characters(node.getChars().toString());
+            } else {
+                html.characters(node.getChars().unescapeNoEntities());
+            }
         } else {
-          content = node.getChars().toString();
+            printWithAbbreviations(node.getChars().toString(), html);
         }
-        html.characters(content);
-      } else {
-        printWithAbbreviations(node.getChars().toString(), html);
-      }
     }
 
 //    @Override

--- a/src/test/resources/dita/inline.dita
+++ b/src/test/resources/dita/inline.dita
@@ -13,7 +13,7 @@
     <p class="- topic/p ">here is a <b class="+ topic/ph hi-d/b ">bold</b> (<b class="+ topic/ph hi-d/b ">bold</b>) claim</p>
     <p class="- topic/p ">here is an <i class="+ topic/ph hi-d/i ">italics</i> (<i class="+ topic/ph hi-d/i ">italics</i>) claim</p>
     <p class="- topic/p ">here is <line-through class="+ topic/ph hi-d/line-through ">strike through</line-through> test</p>
-    <p class="- topic/p ">here is a <codeph class="+ topic/ph pr-d/codeph ">code</codeph> (<codeph class="+ topic/ph pr-d/codeph ">code</codeph>) claim</p>
+    <p class="- topic/p ">here is a <codeph class="+ topic/ph pr-d/codeph ">code \.</codeph> <codeph class="+ topic/ph pr-d/codeph ">contains ` backtick</codeph> (<codeph class="+ topic/ph pr-d/codeph ">two `` backtick</codeph>) claim</p>
     <p class="- topic/p ">here --- mdash --- dash</p>
     <p class="- topic/p ">here -- ndash -- dash</p>
     <p class="- topic/p ">HTML <b class="+ topic/ph hi-d/b ">bold</b> element</p>

--- a/src/test/resources/html/inline.html
+++ b/src/test/resources/html/inline.html
@@ -8,7 +8,7 @@
   <p>here is a <b>bold</b> (<b>bold</b>) claim</p>
   <p>here is an <i>italics</i> (<i>italics</i>) claim</p>
   <p>here is <s>strike through</s> test</p>
-  <p>here is a <code>code</code> (<code>code</code>) claim</p>
+  <p>here is a <code>code \.</code> <code>contains ` backtick</code> (<code>two `` backtick</code>) claim</p>
   <p>here --- mdash --- dash</p>
   <p>here -- ndash -- dash</p>
   <p>HTML <b>bold</b> element</p>

--- a/src/test/resources/lwdita/inline.dita
+++ b/src/test/resources/lwdita/inline.dita
@@ -17,8 +17,7 @@
     <p class="- topic/p ">here is an <i class="+ topic/ph hi-d/i ">italics</i> (<i
         class="+ topic/ph hi-d/i ">italics</i>) claim</p>
     <p class="- topic/p ">here is <line-through class="+ topic/ph hi-d/line-through ">strike through</line-through> test</p>
-    <p class="- topic/p ">here is a <codeph class="+ topic/ph pr-d/codeph ">code</codeph> (<codeph
-      class="+ topic/ph pr-d/codeph ">code</codeph>) claim</p>
+    <p class="- topic/p ">here is a <codeph class="+ topic/ph pr-d/codeph ">code \.</codeph> <codeph class="+ topic/ph pr-d/codeph ">contains ` backtick</codeph> (<codeph class="+ topic/ph pr-d/codeph ">two `` backtick</codeph>) claim</p>
     <p class="- topic/p ">here --- mdash --- dash</p>
     <p class="- topic/p ">here -- ndash -- dash</p>
     <p class="- topic/p ">HTML <b class="+ topic/ph hi-d/b ">bold</b> element</p>

--- a/src/test/resources/markdown/inline.md
+++ b/src/test/resources/markdown/inline.md
@@ -11,7 +11,7 @@ here is an *italics* (*italics*) claim
 
 here is ~~strike through~~ test
 
-here is a `code` (`code`) claim
+here is a `code \.` ``contains ` backtick`` (`two `` backtick`) claim
 
 here --- mdash --- dash
 


### PR DESCRIPTION
I have a markdown that contains the "\\." chars into a code phrase. When converting it to DITA, the "\\" character is removed. 
I propose not to unescape the text that comes from a 'Code' element.