### PR TITLE
Fixed internal links processing

### DIFF
--- a/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
@@ -1466,9 +1466,11 @@ public class CoreNodeRenderer {
     }
 
     private AttributesBuilder getLinkAttributes(final String href) {
-        final AttributesBuilder atts = new AttributesBuilder(XREF_ATTS)
-                .add(ATTRIBUTE_NAME_HREF, href);
-
+      final AttributesBuilder atts = new AttributesBuilder(XREF_ATTS)
+          .add(ATTRIBUTE_NAME_HREF, href);
+      if(href.startsWith("#")) { 
+        atts.add(ATTRIBUTE_NAME_FORMAT, "markdown");
+      } else {
         final URI uri = toURI(href);
         String format = null;
         if (uri.getPath() != null) {
@@ -1498,8 +1500,8 @@ public class CoreNodeRenderer {
         if (uri != null && (uri.isAbsolute() || !uri.isAbsolute() && uri.getPath() != null && uri.getPath().startsWith("/"))) {
             atts.add(ATTRIBUTE_NAME_SCOPE, ATTR_SCOPE_VALUE_EXTERNAL);
         }
-
-        return atts;
+      }
+      return atts;
     }
 
     private String normalize(final String string) {


### PR DESCRIPTION
This fixes the problem from here: #69
Now the internal links will have the 'markdown' format attribute value instead of 'html' and the link in the PDF publishing result will be properly resolved.

This also fixes this one: https://github.com/dita-ot/dita-ot/issues/3560


