### PR TITLE
Add basic support for abbreviation #100

### DIFF
--- a/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
@@ -8,6 +8,7 @@ import com.elovirta.dita.utils.ClasspathURIResolver;
 import com.elovirta.dita.utils.FragmentContentHandler;
 import com.vladsch.flexmark.ast.*;
 import com.vladsch.flexmark.ext.abbreviation.Abbreviation;
+import com.vladsch.flexmark.ext.abbreviation.AbbreviationBlock;
 import com.vladsch.flexmark.ext.anchorlink.AnchorLink;
 import com.vladsch.flexmark.ext.definition.DefinitionItem;
 import com.vladsch.flexmark.ext.definition.DefinitionList;
@@ -167,6 +168,8 @@ public class CoreNodeRenderer {
      */
     public Map<Class<? extends Node>, NodeRenderingHandler<? extends Node>> getNodeRenderingHandlers() {
         return Stream.<NodeRenderingHandler>of(
+                        new NodeRenderingHandler<>(Abbreviation.class, (node, context, html) -> render(node, context, html)),
+                        new NodeRenderingHandler<>(AbbreviationBlock.class, (node, context, html) -> render(node, context, html)),
                         new NodeRenderingHandler<>(YamlFrontMatterBlock.class, (node, context, html) -> render(node, context, html)),
                         new NodeRenderingHandler<>(Footnote.class, (node, context, html) -> render(node, context, html)),
                         new NodeRenderingHandler<>(FootnoteBlock.class, (node, context, html) -> render(node, context, html)),
@@ -352,6 +355,11 @@ public class CoreNodeRenderer {
     }
 
     private void render(final Abbreviation node, final NodeRendererContext context, final SaxWriter html) {
+        html.characters(node.getChars().toString());
+    }
+
+    private void render(final AbbreviationBlock node, final NodeRendererContext context, final SaxWriter html) {
+        // Ignore
     }
 
     private void render(AnchorLink node, final NodeRendererContext context, final SaxWriter html) {

--- a/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
@@ -220,4 +220,9 @@ public class MarkdownReaderTest extends AbstractReaderTest {
         run("jekyll.md");
     }
 
+    @Test
+    public void testAbbreviation() throws Exception {
+        run("abbreviation.md");
+    }
+
 }

--- a/src/test/resources/dita/abbreviation.dita
+++ b/src/test/resources/dita/abbreviation.dita
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  ditaarch:DITAArchVersion="1.2"
+  domains="(topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)"
+  id="abbreviation">
+  <title class="- topic/title ">Abbreviation</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">The HTML specification
+      is maintained by the W3C.
+    </p>
+  </body>
+</topic>

--- a/src/test/resources/lwdita/abbreviation.dita
+++ b/src/test/resources/lwdita/abbreviation.dita
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic " id="abbreviation">
+  <title class="- topic/title ">Abbreviation</title>
+  <shortdesc class="- topic/shortdesc ">The HTML specification
+    is maintained by the W3C.
+  </shortdesc>
+  <body class="- topic/body "/>
+</topic>

--- a/src/test/resources/markdown/abbreviation.md
+++ b/src/test/resources/markdown/abbreviation.md
@@ -1,0 +1,7 @@
+# Abbreviation
+
+The HTML specification
+is maintained by the W3C.
+
+*[HTML]: Hyper Text Markup Language
+*[W3C]:  World Wide Web Consortium


### PR DESCRIPTION
Add basic support for abbreviation.

Because DITA doesn't have `<abbr>` element, just output abbreviation.

Fixes #100