### PR TITLE
Use minimum three spaces in table separator

### DIFF
--- a/src/main/resources/ast2markdown.xsl
+++ b/src/main/resources/ast2markdown.xsl
@@ -189,9 +189,16 @@
           <xsl:variable name="content">
             <xsl:call-template name="process-inline-contents"/>
           </xsl:variable>
-          <xsl:value-of select="if ($align = ('left', 'center')) then ':' else '-'"/>
-          <xsl:for-each select="3 to string-length($content)">-</xsl:for-each>
-          <xsl:value-of select="if ($align = ('right', 'center')) then ':' else '-'"/>
+          <xsl:value-of select="if ($align = ('left', 'center')) then ':' else ''"/>
+          <xsl:variable name="extra-width" as="xs:integer">
+            <xsl:choose>
+              <xsl:when test="$align = 'center'">2</xsl:when>
+              <xsl:when test="$align = ('left', 'right')">1</xsl:when>
+              <xsl:otherwise>0</xsl:otherwise>
+            </xsl:choose>
+          </xsl:variable>
+          <xsl:for-each select="1 to max((3, string-length($content) - $extra-width))">-</xsl:for-each>
+          <xsl:value-of select="if ($align = ('right', 'center')) then ':' else ''"/>
           <xsl:text>|</xsl:text>
         </xsl:for-each>
         <xsl:value-of select="$linefeed"/>

--- a/src/test/resources/ast/ast.xml
+++ b/src/test/resources/ast/ast.xml
@@ -268,6 +268,24 @@ codeblock
             </tbody>
           </table>
         </div>
+        <div class="tablenoborder">
+          <table>
+            <col width="1"/>
+            <col width="1"/>
+            <thead>
+              <tr>
+                <tablecell>A</tablecell>
+                <tablecell>B</tablecell>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <tablecell>1</tablecell>
+                <tablecell>2</tablecell>
+              </tr>
+            </tbody>
+          </table>
+        </div>
         <para>PHP Table:</para>
         <div class="tablenoborder">
           <table>

--- a/src/test/resources/markdown/ast.md
+++ b/src/test/resources/markdown/ast.md
@@ -128,6 +128,10 @@ An inline ![Alt](test.jpg).
 |123|123|123|123|
 |1|1|1|1|
 
+|A|B|
+|---|---|
+|1|2|
+
 PHP Table:
 
 |First Header|Second Header Very long data entry Very long data entry Very long data entry Very long data entry Very long data entry Very long data entry Very long data entry Very long data entry Very long data entry|Third Header|


### PR DESCRIPTION
Use minimum three spaces in table separator.

Fixes #75