### PR TITLE
Support Markdown without first level heading

### DIFF
--- a/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
@@ -656,9 +656,9 @@ public class CoreNodeRenderer {
         if (lwDita && node.getLevel() > 2) {
             throw new ParseException("LwDITA does not support level " + node.getLevel() + " header: " + node.getText());
         }
-        if (node.getLevel() > headerLevel + 1) {
-            throw new ParseException("Header level raised from " + headerLevel + " to " + node.getLevel() + " without intermediate header level");
-        }
+//        if (node.getLevel() > headerLevel + 1) {
+//            throw new ParseException("Header level raised from " + headerLevel + " to " + node.getLevel() + " without intermediate header level");
+//        }
         final StringBuilder buf = new StringBuilder();
         node.getAstExtra(buf);
         Title header = null;
@@ -776,7 +776,7 @@ public class CoreNodeRenderer {
     }
 
     private String getTopicId(final Heading node, final Title header) {
-        if (idFromYaml && node.getLevel() == 1 && node.getPrevious() instanceof YamlFrontMatterBlock) {
+        if (idFromYaml && node.getLevel() == 1 && node.getDocument().getChildOfType(YamlFrontMatterBlock.class) != null) {
             final AbstractYamlFrontMatterVisitor v = new AbstractYamlFrontMatterVisitor();
             v.visit(node.getDocument());
             final Map<String, List<String>> metadata = v.getData();

--- a/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
@@ -1,5 +1,6 @@
 package com.elovirta.dita.markdown;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class MDitaReaderTest extends MarkdownReaderTest {
@@ -18,5 +19,19 @@ public class MDitaReaderTest extends MarkdownReaderTest {
     @Test(expected = ParseException.class)
     public void testHeader() throws Exception {
         run("header.md");
+    }
+
+    @Override
+    @Ignore
+    @Test
+    public void testGitHubWiki() throws Exception {
+//        run("missing_root_header.md");
+    }
+
+    @Override
+    @Ignore
+    @Test
+    public void testGitHubWikiWithYaml() throws Exception {
+//        run("missing_root_header_with_yaml.md");
     }
 }

--- a/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
@@ -49,6 +49,11 @@ public class MarkdownReaderTest extends AbstractReaderTest {
     }
 
     @Test
+    public void testGitHubWiki() throws Exception {
+        run("missing_root_header.md");
+    }
+
+    @Test
     public void testHeaderAttributes() throws Exception {
         run("header_attributes.md");
     }

--- a/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
@@ -54,6 +54,11 @@ public class MarkdownReaderTest extends AbstractReaderTest {
     }
 
     @Test
+    public void testGitHubWikiWithYaml() throws Exception {
+        run("missing_root_header_with_yaml.md");
+    }
+
+    @Test
     public void testHeaderAttributes() throws Exception {
         run("header_attributes.md");
     }

--- a/src/test/java/com/elovirta/dita/utils/AbstractReaderTest.java
+++ b/src/test/java/com/elovirta/dita/utils/AbstractReaderTest.java
@@ -19,6 +19,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.InputStream;
+import java.net.URI;
 
 public abstract class AbstractReaderTest {
 
@@ -57,6 +58,7 @@ public abstract class AbstractReaderTest {
             act = db.newDocument();
             final Transformer t = transformerFactory.newTransformer();
             final InputSource i = new InputSource(in);
+            i.setSystemId(URI.create("classpath:/" + input).toString());
             t.transform(new SAXSource(r, i), new DOMResult(act));
         }
 

--- a/src/test/resources/dita/missing_root_header.dita
+++ b/src/test/resources/dita/missing_root_header.dita
@@ -1,0 +1,16 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  id="missing-root-header" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">missing root header</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">Root topic content.</p>
+  </body>
+  <topic class="- topic/topic "
+    domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+    id="nested-topic" ditaarch:DITAArchVersion="1.3">
+    <title class="- topic/title ">Nested Topic</title>
+    <body class="- topic/body ">
+      <p class="- topic/p ">Nested topic content.</p>
+    </body>
+  </topic>
+</topic>

--- a/src/test/resources/dita/missing_root_header_with_yaml.dita
+++ b/src/test/resources/dita/missing_root_header_with_yaml.dita
@@ -1,0 +1,8 @@
+<topic xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- topic/topic "
+  domains="(topic abbrev-d)                            a(props deliveryTarget)                            (topic equation-d)                            (topic hazard-d)                            (topic hi-d)                            (topic indexing-d)                            (topic markup-d)                            (topic mathml-d)                            (topic pr-d)                            (topic relmgmt-d)                            (topic sw-d)                            (topic svg-d)                            (topic ui-d)                            (topic ut-d)                            (topic markup-d xml-d)   "
+  id="yaml-title" ditaarch:DITAArchVersion="1.3">
+  <title class="- topic/title ">YAML Title</title>
+  <body class="- topic/body ">
+    <p class="- topic/p ">Root topic content.</p>
+  </body>
+</topic>

--- a/src/test/resources/markdown/missing_root_header.md
+++ b/src/test/resources/markdown/missing_root_header.md
@@ -1,0 +1,8 @@
+
+
+
+Root topic content.
+
+## Nested Topic
+
+Nested topic content.

--- a/src/test/resources/markdown/missing_root_header_with_yaml.md
+++ b/src/test/resources/markdown/missing_root_header_with_yaml.md
@@ -1,0 +1,6 @@
+---
+id: yaml-id
+title: "YAML Title"
+---
+
+Root topic content.


### PR DESCRIPTION
Support Markdown files without first level heading. A first level heading is generate from either YAML metadata `title` key or from file name. Files like these are commonly used in wikis.