### PR TITLE
Add feature support for built-in DITA renderer options

### DIFF
--- a/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
+++ b/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
@@ -104,9 +104,31 @@ public class MarkdownReader implements XMLReader {
         return false;
     }
 
+    /**
+     * Set the value of a feature flag.
+     *
+     * <dl>
+     *     <dt><code>http://lwdita.org/sax/features/shortdesc-paragraph</code></dt>
+     *     <dd>Treat first paragraph as shortdesc.</dd>
+     *     <dt><code>http://lwdita.org/sax/features/id-from-yaml</code></dt>
+     *     <dd>Read topic ID from YAML header if available.</dd>
+     *     <dt><code>http://lwdita.org/sax/features/mdita</code></dt>
+     *     <dd>Parse as MDITA.</dd>
+     * </dl>
+     */
     @Override
     public void setFeature(String name, boolean value) throws SAXNotRecognizedException, SAXNotSupportedException {
-        // NOOP
+        switch (name) {
+            case "http://lwdita.org/sax/features/shortdesc-paragraph":
+                options.set(DitaRenderer.SHORTDESC_PARAGRAPH, value);
+                break;
+            case "http://lwdita.org/sax/features/id-from-yaml":
+                options.set(DitaRenderer.ID_FROM_YAML, value);
+                break;
+            case "http://lwdita.org/sax/features/mdita":
+                options.set(DitaRenderer.LW_DITA, value);
+                break;
+        }
     }
 
     @Override

--- a/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
@@ -2,6 +2,8 @@ package com.elovirta.dita.markdown;
 
 import org.junit.Ignore;
 import org.junit.Test;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
 
 public class MDitaReaderTest extends MarkdownReaderTest {
 


### PR DESCRIPTION
Support parser features:

* `http://lwdita.org/sax/features/shortdesc-paragraph`: Treat first paragraph as shortdesc.
* `http://lwdita.org/sax/features/id-from-yaml`: Read topic ID from YAML header if available.
* `http://lwdita.org/sax/features/mdita`: Parse as MDITA.