### PR TITLE
Add support for Locator

### DIFF
--- a/src/main/java/com/elovirta/dita/markdown/DitaRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/DitaRenderer.java
@@ -10,7 +10,9 @@ import com.vladsch.flexmark.util.data.*;
 import com.vladsch.flexmark.util.sequence.LineAppendable;
 import com.vladsch.flexmark.util.sequence.TagRange;
 import org.xml.sax.ContentHandler;
+import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
+import org.xml.sax.ext.Locator2Impl;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -139,6 +141,7 @@ public class DitaRenderer {
         @Override
         public void render(Node node) {
             try {
+                saxWriter.startDocument();
                 saxWriter.contentHandler.startDocument();
                 saxWriter.contentHandler.startPrefixMapping(ATTRIBUTE_PREFIX_DITAARCHVERSION, DITA_NAMESPACE);
                 renderNode(node, this);

--- a/src/main/java/com/elovirta/dita/markdown/DitaRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/DitaRenderer.java
@@ -10,9 +10,7 @@ import com.vladsch.flexmark.util.data.*;
 import com.vladsch.flexmark.util.sequence.LineAppendable;
 import com.vladsch.flexmark.util.sequence.TagRange;
 import org.xml.sax.ContentHandler;
-import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
-import org.xml.sax.ext.Locator2Impl;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -142,12 +140,12 @@ public class DitaRenderer {
         public void render(Node node) {
             try {
                 saxWriter.startDocument();
-                saxWriter.contentHandler.startDocument();
-                saxWriter.contentHandler.startPrefixMapping(ATTRIBUTE_PREFIX_DITAARCHVERSION, DITA_NAMESPACE);
+                saxWriter.getContentHandler().startDocument();
+                saxWriter.getContentHandler().startPrefixMapping(ATTRIBUTE_PREFIX_DITAARCHVERSION, DITA_NAMESPACE);
                 renderNode(node, this);
                 saxWriter.close();
-                saxWriter.contentHandler.endPrefixMapping(ATTRIBUTE_PREFIX_DITAARCHVERSION);
-                saxWriter.contentHandler.endDocument();
+                saxWriter.getContentHandler().endPrefixMapping(ATTRIBUTE_PREFIX_DITAARCHVERSION);
+                saxWriter.getContentHandler().endDocument();
             } catch (SAXException e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
+++ b/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
@@ -1,6 +1,5 @@
 package com.elovirta.dita.markdown;
 
-import com.elovirta.dita.utils.ClasspathURIResolver;
 import com.google.common.annotations.VisibleForTesting;
 import com.vladsch.flexmark.ast.Heading;
 import com.vladsch.flexmark.ast.Text;
@@ -25,17 +24,9 @@ import com.vladsch.flexmark.util.ast.Node;
 import com.vladsch.flexmark.util.data.MutableDataSet;
 import com.vladsch.flexmark.util.sequence.BasedSequence;
 import com.vladsch.flexmark.util.sequence.BasedSequenceImpl;
-import org.dita.dost.util.FileUtils;
-import org.dita.dost.util.URLUtils;
 import org.xml.sax.*;
+import org.xml.sax.helpers.XMLFilterImpl;
 
-import javax.xml.transform.Templates;
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.sax.SAXResult;
-import javax.xml.transform.sax.SAXTransformerFactory;
-import javax.xml.transform.sax.TransformerHandler;
-import javax.xml.transform.stream.StreamSource;
 import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -53,8 +44,6 @@ import static org.apache.commons.io.IOUtils.copy;
 public class MarkdownReader implements XMLReader {
 
     final Parser p;
-    private SAXTransformerFactory tf;
-    private Templates t;
     private final MutableDataSet options;
 
     EntityResolver resolver;
@@ -85,13 +74,6 @@ public class MarkdownReader implements XMLReader {
                 .set(TablesExtension.DISCARD_EXTRA_COLUMNS, true)
                 .set(TablesExtension.HEADER_SEPARATOR_COLUMN_MATCH, true)
         );
-        try (InputStream style = getClass().getResourceAsStream("/specialize.xsl")) {
-            tf = (SAXTransformerFactory) TransformerFactory.newInstance();
-            tf.setURIResolver(new ClasspathURIResolver(tf.getURIResolver()));
-            t = tf.newTemplates(new StreamSource(style, "classpath:///specialize.xsl"));
-        } catch (final IOException | TransformerConfigurationException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     public MarkdownReader(final MutableDataSet options) {
@@ -326,18 +308,10 @@ public class MarkdownReader implements XMLReader {
 
     private void parseAST(final Document root) throws SAXException {
         ContentHandler res = contentHandler;
-        if (t != null) {
-            final TransformerHandler h;
-            try {
-                h = tf.newTransformerHandler(t);
-            } catch (final TransformerConfigurationException e) {
-                throw new SAXException(e);
-            }
-            h.setResult(new SAXResult(res));
-            res = h;
-        }
+        final XMLFilterImpl specialize = new SpecializeFilter();
+        specialize.setContentHandler(res);
+        res = specialize;
         final DitaRenderer s = new DitaRenderer(options);
         s.render(root, res);
     }
-
 }

--- a/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
+++ b/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
@@ -178,7 +178,7 @@ public class MarkdownReader implements XMLReader {
         }
     }
 
-    private void validate(Document root)  {
+    private void validate(Document root) {
         int level = 0;
         Node node = root.getFirstChild();
         while (node != null) {

--- a/src/main/java/com/elovirta/dita/markdown/MetadataSerializerImpl.java
+++ b/src/main/java/com/elovirta/dita/markdown/MetadataSerializerImpl.java
@@ -50,11 +50,11 @@ public class MetadataSerializerImpl {
         write(header, TOPIC_PERMISSIONS, "view", html);
         if (header.containsKey(TOPIC_AUDIENCE.localName) || header.containsKey(TOPIC_CATEGORY.localName)
                 || header.containsKey(TOPIC_KEYWORD.localName)) {
-            html.startElement(TOPIC_METADATA, buildAtts(TOPIC_METADATA));
+            html.startElement(node, TOPIC_METADATA, buildAtts(TOPIC_METADATA));
             write(header, TOPIC_AUDIENCE, ATTRIBUTE_NAME_AUDIENCE, html);
             write(header, TOPIC_CATEGORY, html);
             if (header.containsKey(TOPIC_KEYWORD.localName)) {
-                html.startElement(TOPIC_KEYWORDS, buildAtts(TOPIC_KEYWORDS));
+                html.startElement(node, TOPIC_KEYWORDS, buildAtts(TOPIC_KEYWORDS));
                 write(header, TOPIC_KEYWORD, html);
                 html.endElement();
             }
@@ -66,7 +66,7 @@ public class MetadataSerializerImpl {
         final List<String> keys = Sets.difference(header.keySet(), knownKeys).stream().sorted().collect(Collectors.toList());
         for (String key : keys) {
             for (String val : header.get(key)) {
-                html.startElement(TOPIC_DATA.localName, new XMLUtils.AttributesBuilder()
+                html.startElement(node, TOPIC_DATA.localName, new XMLUtils.AttributesBuilder()
                         .add(ATTRIBUTE_NAME_CLASS, TOPIC_DATA.toString())
                         .add(ATTRIBUTE_NAME_NAME, key)
                         .add(ATTRIBUTE_NAME_VALUE, val)
@@ -79,7 +79,7 @@ public class MetadataSerializerImpl {
     private void write(final Map<String, List<String>> header, final DitaClass elem, SaxWriter html) {
         if (header.containsKey(elem.localName)) {
             for (String v : header.get(elem.localName)) {
-                html.startElement(elem, buildAtts(elem));
+                html.startElement(null, elem, buildAtts(elem));
                 if (v != null) {
                     html.characters(v);
                 }
@@ -91,7 +91,7 @@ public class MetadataSerializerImpl {
     private void write(final Map<String, List<String>> header, final DitaClass elem, final String attr, SaxWriter html) {
         if (header.containsKey(elem.localName)) {
             for (String v : header.get(elem.localName)) {
-                html.startElement(elem, new XMLUtils.AttributesBuilder()
+                html.startElement(null, elem, new XMLUtils.AttributesBuilder()
                         .add(ATTRIBUTE_NAME_CLASS, elem.toString())
                         .add(attr, v)
                         .build());

--- a/src/main/java/com/elovirta/dita/markdown/SaxWriter.java
+++ b/src/main/java/com/elovirta/dita/markdown/SaxWriter.java
@@ -29,7 +29,7 @@ public class SaxWriter {
         contentHandler.setDocumentLocator(locator);
     }
 
-    private void setLocation(Node node) {
+    public void setLocation(Node node) {
         if (node != null) {
             locator.setLineNumber(node.getLineNumber() + 1);
             locator.setColumnNumber(node.getStartOffset() - node.getStartOfLine() + 1);

--- a/src/main/java/com/elovirta/dita/markdown/SaxWriter.java
+++ b/src/main/java/com/elovirta/dita/markdown/SaxWriter.java
@@ -33,7 +33,7 @@ public class SaxWriter {
         if (node != null) {
             locator.setLineNumber(node.getLineNumber() + 1);
 //            locator.setColumnNumber(node.getStartOffset());
-            locator.setColumnNumber(node.getEndOfLine() - node.getStartOfLine());
+            locator.setColumnNumber(node.getStartOffset() - node.getStartOfLine() + 1);
         }
     }
 

--- a/src/main/java/com/elovirta/dita/markdown/SaxWriter.java
+++ b/src/main/java/com/elovirta/dita/markdown/SaxWriter.java
@@ -29,6 +29,10 @@ public class SaxWriter {
         contentHandler.setDocumentLocator(locator);
     }
 
+    public void setDocumentLocator() {
+        contentHandler.setDocumentLocator(locator);
+    }
+
     public void setLocation(Node node) {
         if (node != null) {
             locator.setLineNumber(node.getLineNumber() + 1);

--- a/src/main/java/com/elovirta/dita/markdown/SaxWriter.java
+++ b/src/main/java/com/elovirta/dita/markdown/SaxWriter.java
@@ -24,6 +24,8 @@ public class SaxWriter {
     }
 
     public void startDocument() {
+        locator.setLineNumber(1);
+        locator.setColumnNumber(1);
         contentHandler.setDocumentLocator(locator);
     }
 

--- a/src/main/java/com/elovirta/dita/markdown/SaxWriter.java
+++ b/src/main/java/com/elovirta/dita/markdown/SaxWriter.java
@@ -30,7 +30,8 @@ public class SaxWriter {
     private void setLocation(Node node) {
         if (node != null) {
             locator.setLineNumber(node.getLineNumber() + 1);
-            locator.setColumnNumber(node.getStartOffset());
+//            locator.setColumnNumber(node.getStartOffset());
+            locator.setColumnNumber(node.getEndOfLine() - node.getStartOfLine());
         }
     }
 

--- a/src/main/java/com/elovirta/dita/markdown/SaxWriter.java
+++ b/src/main/java/com/elovirta/dita/markdown/SaxWriter.java
@@ -3,8 +3,10 @@ package com.elovirta.dita.markdown;
 import com.vladsch.flexmark.util.ast.Node;
 import org.dita.dost.util.DitaClass;
 import org.xml.sax.ContentHandler;
+import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
 import org.xml.sax.ext.Locator2Impl;
+import org.xml.sax.helpers.XMLFilterImpl;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -14,23 +16,27 @@ import static javax.xml.XMLConstants.NULL_NS_URI;
 /**
  * Write to SAX ContentHandler.
  */
-public class SaxWriter {
+public class SaxWriter extends XMLFilterImpl {
     public final Deque<String> tagStack = new ArrayDeque<>();
-    public final ContentHandler contentHandler;
     private final Locator2Impl locator = new Locator2Impl();
 
     public SaxWriter(ContentHandler out) {
-        this.contentHandler = out;
+        setContentHandler(out);
     }
 
     public void startDocument() {
         locator.setLineNumber(1);
         locator.setColumnNumber(1);
-        contentHandler.setDocumentLocator(locator);
+        getContentHandler().setDocumentLocator(locator);
+    }
+
+    @Override
+    public void setDocumentLocator(Locator locator) {
+        // Ignore
     }
 
     public void setDocumentLocator() {
-        contentHandler.setDocumentLocator(locator);
+        getContentHandler().setDocumentLocator(locator);
     }
 
     public void setLocation(Node node) {
@@ -47,7 +53,7 @@ public class SaxWriter {
     public void startElement(final Node node, final String tag, final org.xml.sax.Attributes atts) {
         setLocation(node);
         try {
-            contentHandler.startElement(NULL_NS_URI, tag, tag, atts);
+            getContentHandler().startElement(NULL_NS_URI, tag, tag, atts);
         } catch (final SAXException e) {
             throw new ParseException(e);
         }
@@ -66,7 +72,7 @@ public class SaxWriter {
 
     public void endElement(final String tag) {
         try {
-            contentHandler.endElement(NULL_NS_URI, tag, tag);
+            getContentHandler().endElement(NULL_NS_URI, tag, tag);
         } catch (final SAXException e) {
             throw new ParseException(e);
         }
@@ -74,7 +80,7 @@ public class SaxWriter {
 
     public void characters(final char c) {
         try {
-            contentHandler.characters(new char[]{c}, 0, 1);
+            getContentHandler().characters(new char[]{c}, 0, 1);
         } catch (final SAXException e) {
             throw new ParseException(e);
         }
@@ -83,7 +89,7 @@ public class SaxWriter {
     public void characters(final String t) {
         final char[] cs = t.toCharArray();
         try {
-            contentHandler.characters(cs, 0, cs.length);
+            getContentHandler().characters(cs, 0, cs.length);
         } catch (final SAXException e) {
             throw new ParseException(e);
         }
@@ -97,7 +103,7 @@ public class SaxWriter {
 
     public void processingInstruction(String name, String data) {
         try {
-            contentHandler.processingInstruction(name, data != null ? data : "");
+            getContentHandler().processingInstruction(name, data != null ? data : "");
         } catch (final SAXException e) {
             throw new ParseException(e);
         }

--- a/src/main/java/com/elovirta/dita/markdown/SaxWriter.java
+++ b/src/main/java/com/elovirta/dita/markdown/SaxWriter.java
@@ -1,8 +1,10 @@
 package com.elovirta.dita.markdown;
 
+import com.vladsch.flexmark.util.ast.Node;
 import org.dita.dost.util.DitaClass;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
+import org.xml.sax.ext.Locator2Impl;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -15,16 +17,29 @@ import static javax.xml.XMLConstants.NULL_NS_URI;
 public class SaxWriter {
     public final Deque<String> tagStack = new ArrayDeque<>();
     public final ContentHandler contentHandler;
+    private final Locator2Impl locator = new Locator2Impl();
 
     public SaxWriter(ContentHandler out) {
         this.contentHandler = out;
     }
 
-    public void startElement(final DitaClass tag, final org.xml.sax.Attributes atts) {
-        startElement(tag.localName, atts);
+    public void startDocument() {
+        contentHandler.setDocumentLocator(locator);
     }
 
-    public void startElement(final String tag, final org.xml.sax.Attributes atts) {
+    private void setLocation(Node node) {
+        if (node != null) {
+            locator.setLineNumber(node.getLineNumber() + 1);
+            locator.setColumnNumber(node.getStartOffset());
+        }
+    }
+
+    public void startElement(final Node node, final DitaClass tag, final org.xml.sax.Attributes atts) {
+        startElement(node, tag.localName, atts);
+    }
+
+    public void startElement(final Node node, final String tag, final org.xml.sax.Attributes atts) {
+        setLocation(node);
         try {
             contentHandler.startElement(NULL_NS_URI, tag, tag, atts);
         } catch (final SAXException e) {

--- a/src/main/java/com/elovirta/dita/markdown/SaxWriter.java
+++ b/src/main/java/com/elovirta/dita/markdown/SaxWriter.java
@@ -32,7 +32,6 @@ public class SaxWriter {
     private void setLocation(Node node) {
         if (node != null) {
             locator.setLineNumber(node.getLineNumber() + 1);
-//            locator.setColumnNumber(node.getStartOffset());
             locator.setColumnNumber(node.getStartOffset() - node.getStartOfLine() + 1);
         }
     }

--- a/src/main/java/com/elovirta/dita/markdown/SpecializeFilter.java
+++ b/src/main/java/com/elovirta/dita/markdown/SpecializeFilter.java
@@ -246,14 +246,14 @@ public class SpecializeFilter extends XMLFilterImpl {
     }
 
     public void doStartElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
-        System.out.printf("<%s>%n", localName);
+//        System.out.printf("<%s>%n", localName);
         super.startElement(uri, localName, qName, atts);
         elementStack.push(localName);
     }
 
     public void doEndElement(String uri, String localName, String qName) throws SAXException {
         final String l = elementStack.pop();
-        System.out.printf("</%s = %s>%n", l, localName);
+//        System.out.printf("</%s = %s>%n", l, localName);
         super.endElement(uri, l, l);
     }
 

--- a/src/main/java/com/elovirta/dita/markdown/SpecializeFilter.java
+++ b/src/main/java/com/elovirta/dita/markdown/SpecializeFilter.java
@@ -1,0 +1,378 @@
+package com.elovirta.dita.markdown;
+
+import com.google.common.base.Strings;
+import org.dita.dost.util.Constants;
+import org.dita.dost.util.DitaClass;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+import org.xml.sax.helpers.XMLFilterImpl;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static javax.xml.XMLConstants.NULL_NS_URI;
+import static org.dita.dost.util.Constants.*;
+
+public class SpecializeFilter extends XMLFilterImpl {
+
+    private static int DEPTH_IN_BODY = 3;
+
+    private enum Type {
+        TOPIC,
+        CONCEPT,
+        TASK,
+        REFERENCE
+    }
+
+    private enum TaskState {
+        CONTEXT,
+        STEPS,
+        RESULT
+    }
+
+    /** Topic type stack. Default to topic in case of compound type */
+    private Deque<Type> typeStack = new ArrayDeque<>(Arrays.asList(Type.TOPIC));
+//    private Type type = Type.TOPIC;
+    private boolean inBody = false;
+    private boolean inStep = false;
+    private int paragraphCountInStep = 0;
+    private int depth = 0;
+    private boolean wrapOpen = false;
+    private TaskState taskState = null;
+//    private boolean contextWrapOpen = false;
+    private boolean infoWrapOpen = false;
+
+    private Deque<String> elementStack = new ArrayDeque<>();
+
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
+//        System.err.println("#" + localName + " infoWrapOpen="+infoWrapOpen);
+        depth++;
+
+        if (localName.equals(TOPIC_TOPIC.localName)) {
+            depth = 1;
+            final Collection<String> outputclasses = getOutputclass(atts);
+            if (outputclasses.contains(CONCEPT_CONCEPT.localName)) {
+                typeStack.push(Type.CONCEPT);
+            } else if (outputclasses.contains(TASK_TASK.localName)) {
+                typeStack.push(Type.TASK);
+            } else if (outputclasses.contains(REFERENCE_REFERENCE.localName)) {
+                typeStack.push(Type.REFERENCE);
+            } else {
+                typeStack.push(typeStack.peek());
+            }
+        }
+
+        switch (typeStack.peek()) {
+            case CONCEPT:
+                switch (localName) {
+                    case "topic":
+                        renameStartElement(Constants.CONCEPT_CONCEPT, atts);
+                        break;
+                    case "body":
+                        renameStartElement(Constants.CONCEPT_CONBODY, atts);
+                        break;
+                    default:
+                        doStartElement(uri, localName, qName, atts);
+                }
+                break;
+            case TASK:
+                switch (localName) {
+                    case "topic":
+                        renameStartElement(TASK_TASK, atts);
+                        taskState = null;
+                        break;
+                    case "body":
+                        inBody = true;
+                        renameStartElement(TASK_TASKBODY, atts);
+                        break;
+                    case "ol":
+                        if (inBody && depth == DEPTH_IN_BODY) {
+                            if (taskState == TaskState.CONTEXT) {
+                                doEndElement(uri, TASK_CONTEXT.localName, TASK_CONTEXT.localName);
+                            }
+                            taskState = TaskState.STEPS;
+                            renameStartElement(Constants.TASK_STEPS, atts);
+                        } else {
+                            doStartElement(uri, localName, qName, atts);
+                        }
+                        break;
+                    case "ul":
+                        if (inBody && depth == DEPTH_IN_BODY) {
+                            if (taskState == TaskState.CONTEXT) {
+                                doEndElement(uri, TASK_CONTEXT.localName, TASK_CONTEXT.localName);
+                            }
+                            taskState = TaskState.STEPS;
+                            renameStartElement(TASK_STEPS_UNORDERED, atts);
+                        } else {
+                            doStartElement(uri, localName, qName, atts);
+                        }
+                        break;
+                    case "li":
+                        if (inBody && depth == 4) {
+                            renameStartElement(TASK_STEP, atts);
+                            inStep = true;
+                        } else {
+                            doStartElement(uri, localName, qName, atts);
+                        }
+                        break;
+                    default:
+                        if (inBody && depth == DEPTH_IN_BODY) {
+//                            switch (localName) {
+//                                case "ol":
+//                                case "ul":
+//                                    if (true) throw new RuntimeException();
+//                                    // No need to wrap
+//                                    if (taskState == TaskState.CONTEXT) {
+//                                        taskState = TaskState.STEPS;
+//                                        doEndElement(uri, TASK_CONTEXT.localName, TASK_CONTEXT.localName);
+//                                    }
+//                                    break;
+//                                default:
+                            if (taskState == null) {
+                                AttributesImpl sectionAtts = new AttributesImpl();
+                                sectionAtts.addAttribute(NULL_NS_URI, "class", "class", "CDATA", TASK_CONTEXT.toString());
+                                doStartElement(uri, TASK_CONTEXT.localName, TASK_CONTEXT.localName, sectionAtts);
+                                taskState = TaskState.CONTEXT;
+                            }
+//                                    break;
+//                            }
+                            doStartElement(uri, localName, qName, atts);
+                        } else if (inStep && depth == 5) {
+                            switch (localName) {
+                                case "p":
+                                    paragraphCountInStep++;
+//                                    System.out.printf("p %d in step%n", paragraphCountInStep);
+                                    if (paragraphCountInStep == 1) {
+                                        renameStartElement(TASK_CMD, atts);
+                                    } else if (paragraphCountInStep == 2 && !infoWrapOpen) {
+                                        AttributesImpl res = new AttributesImpl(atts);
+                                        res.addAttribute(NULL_NS_URI, "class", "class", "CDATA", TASK_INFO.toString());
+                                        doStartElement(NULL_NS_URI, TASK_INFO.localName, TASK_INFO.localName, res);
+                                        infoWrapOpen = true;
+                                        doStartElement(uri, localName, qName, atts);
+                                    } else {
+                                        doStartElement(uri, localName, qName, atts);
+                                    }
+                                    break;
+                                default:
+                                    if (!infoWrapOpen) {
+                                        AttributesImpl res = new AttributesImpl(atts);
+                                        res.addAttribute(NULL_NS_URI, "class", "class", "CDATA", TASK_INFO.toString());
+                                        doStartElement(NULL_NS_URI, TASK_INFO.localName, TASK_INFO.localName, res);
+                                        infoWrapOpen = true;
+//                                        doStartElement(uri, localName, qName, atts);
+                                    }
+                                    doStartElement(uri, localName, qName, atts);
+                                    break;
+                            }
+                        } else {
+                            doStartElement(uri, localName, qName, atts);
+                        }
+                }
+                break;
+            case REFERENCE:
+                switch (localName) {
+                    case "topic":
+                        renameStartElement(REFERENCE_REFERENCE, atts);
+                        break;
+                    case "body":
+                        inBody = true;
+                        renameStartElement(REFERENCE_REFBODY, atts);
+                        break;
+                    default:
+                        if (inBody && depth == DEPTH_IN_BODY) {
+                            switch (localName) {
+                                case "table":
+                                case "section":
+                                    if (wrapOpen) {
+                                        wrapOpen = false;
+                                        doEndElement(uri, "section", "section");
+                                    }
+                                    break;
+                                default:
+                                    wrapOpen = true;
+                                    AttributesImpl sectionAtts = new AttributesImpl();
+                                    sectionAtts.addAttribute(NULL_NS_URI, "class", "class", "CDATA", "- topic/section ");
+                                    doStartElement(uri, "section", "section", sectionAtts);
+                                    break;
+                            }
+                            doStartElement(uri, localName, qName, atts);
+                        } else {
+                            doStartElement(uri, localName, qName, atts);
+                        }
+                }
+                break;
+            default:
+                doStartElement(uri, localName, qName, atts);
+        }
+    }
+
+    @Override
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+//        System.err.println("#/" + localName);
+        switch (typeStack.peek()) {
+            case TASK:
+                switch (localName) {
+                    case "body":
+                        if (taskState == TaskState.CONTEXT) {
+                            taskState = null;
+                            doEndElement(uri, TASK_CONTEXT.localName, TASK_CONTEXT.localName);
+                        }
+                        inBody = false;
+                        doEndElement(uri, localName, qName);
+                        break;
+                    case "li":
+                        if (inStep && depth == 4) {
+                            inStep = false;
+                            paragraphCountInStep = 0;
+                            if (infoWrapOpen) {
+                                doEndElement(NULL_NS_URI, TASK_INFO.localName, TASK_INFO.localName);
+                                infoWrapOpen = false;
+                            }
+                        }
+                        doEndElement(uri, localName, qName);
+                        break;
+                    default:
+                        doEndElement(uri, localName, qName);
+                }
+                break;
+            case REFERENCE:
+                switch (localName) {
+                    case "body":
+                        if (wrapOpen) {
+                            wrapOpen = false;
+                            doEndElement(uri, TOPIC_SECTION.localName, TOPIC_SECTION.localName);
+                        }
+                        doEndElement(uri, localName, qName);
+                        inBody = false;
+                        break;
+                    default:
+                        doEndElement(uri, localName, qName);
+                }
+                break;
+            case CONCEPT:
+            default:
+                doEndElement(uri, localName, qName);
+        }
+
+        if (localName.equals(TOPIC_TOPIC.localName)) {
+            typeStack.pop();
+        }
+
+        depth--;
+    }
+
+    public void doStartElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
+//        System.out.printf("%s<%s>%n", Strings.repeat(" ", depth), localName);
+        super.startElement(uri, localName, qName, atts);
+        elementStack.push(localName);
+    }
+
+    public void doEndElement(String uri, String localName, String qName) throws SAXException {
+        final String l = elementStack.pop();
+//        System.out.printf("%s</%s = %s>%n", Strings.repeat(" ", depth), l, localName);
+        super.endElement(uri, l, l);
+    }
+
+    private void renameStartElement(DitaClass cls, Attributes atts) throws SAXException {
+        AttributesImpl res = new AttributesImpl(atts);
+        res.addAttribute(NULL_NS_URI, "class", "class", "CDATA", cls.toString());
+        final int i = res.getIndex(NULL_NS_URI, "outputclass");
+        if (i != -1) {
+            res.removeAttribute(i);
+        }
+        doStartElement(NULL_NS_URI, cls.localName, cls.localName, res);
+    }
+
+    private void renameEndElement(DitaClass cls) throws SAXException {
+        doEndElement(NULL_NS_URI, cls.localName, cls.localName);
+    }
+
+    private Collection<String> getOutputclass(Attributes atts) {
+        final String outputclass = atts.getValue("outputclass");
+        if (outputclass == null) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(outputclass.trim().split("\\s+"));
+    }
+
+/*
+# reference
+body/* -> wrap everything not table or section into section
+
+# concept
+topic -> concept
+body -> conbody
+
+# task
+topic -> task
+body -> taskbody
+body/ol -> steps
+body/ul -> steps-unordered
+
+  <xsl:template match="body" mode="task">
+    <taskbody class="- topic/body task/taskbody ">
+      <xsl:apply-templates select="@* except @class" mode="#current"/>
+      <xsl:for-each-group select="*" group-adjacent="contains(@class, ' topic/ol ') or contains(@class, ' topic/ul ') or contains(@class, ' topic/section ')">
+        <xsl:choose>
+          <xsl:when test="current-grouping-key() and empty(preceding-sibling::*)">
+            <context class="- topic/section task/context ">
+              <xsl:apply-templates select="current-group()/*" mode="#current"/>
+            </context>
+          </xsl:when>
+          <xsl:when test="current-grouping-key()">
+            <xsl:apply-templates select="current-group()" mode="#current"/>
+          </xsl:when>
+          <xsl:when test="current-group()[1]/preceding-sibling::*[contains(@class, ' topic/ol ') or contains(@class, ' topic/ul ')]">
+            <result class="- topic/section task/result ">
+              <xsl:apply-templates select="current-group()" mode="#current"/>
+            </result>
+          </xsl:when>
+          <xsl:otherwise>
+            <context class="- topic/section task/context ">
+              <xsl:apply-templates select="current-group()" mode="#current"/>
+            </context>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:for-each-group>
+    </taskbody>
+  </xsl:template>
+
+
+  <xsl:template match="body/ol/li | body/ul/li" mode="task">
+    <step class="- topic/li task/step ">
+      <xsl:apply-templates select="@* except @class" mode="#current"/>
+
+      <xsl:variable name="first-block" select="*[x:is-block(.)][1]" as="element()?"/>
+      <xsl:variable name="head" select="if (exists($first-block)) then node()[. &lt;&lt; $first-block] else node()" as="node()*"/>
+      <xsl:variable name="tail" select="if (exists($first-block)) then ($first-block | node()[. &gt;&gt; $first-block]) else ()" as="node()*"/>
+      <xsl:choose>
+        <xsl:when test="$head[self::* or normalize-space()]">
+          <cmd class="- topic/ph task/cmd ">
+            <xsl:copy-of select="$head"/>
+          </cmd>
+          <xsl:if test="*">
+            <info class="- topic/itemgroup task/info ">
+              <xsl:apply-templates select="$tail" mode="#current"/>
+            </info>
+          </xsl:if>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:for-each select="$tail[1]">
+            <cmd class="- topic/ph task/cmd ">
+              <xsl:apply-templates select="@* except @class | node()" mode="#current"/>
+            </cmd>
+          </xsl:for-each>
+          <xsl:if test="$tail[position() ge 2][self::* or normalize-space()]">
+            <info class="- topic/itemgroup task/info ">
+              <xsl:apply-templates select="$tail[position() gt 1]" mode="#current"/>
+            </info>
+          </xsl:if>
+        </xsl:otherwise>
+      </xsl:choose>
+    </step>
+  </xsl:template>
+ */
+}

--- a/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
@@ -44,7 +44,6 @@ import org.dita.dost.util.SaxCache.StartElementEvent;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-import org.xml.sax.ext.Locator2Impl;
 import org.xml.sax.helpers.AttributesImpl;
 import org.xml.sax.helpers.XMLFilterImpl;
 
@@ -849,7 +848,7 @@ public class CoreNodeRenderer {
     private void render(final HtmlBlock node, final NodeRendererContext context, final SaxWriter html) {
         final String text = node.getChars().toString();
         final FragmentContentHandler fragmentFilter = new FragmentContentHandler();
-        fragmentFilter.setContentHandler(html.contentHandler);
+        fragmentFilter.setContentHandler(html);
         final TransformerHandler h;
         try {
             h = tf.newTransformerHandler(t);
@@ -892,7 +891,7 @@ public class CoreNodeRenderer {
                 parser.parse(new InputSource(in));
                 for (SaxEvent event : cache.events) {
                     if (event instanceof EndElementEvent) {
-                        event.write(html.contentHandler);
+                        event.write(html);
                     }
                 }
             } catch (IOException | SAXException e) {
@@ -903,7 +902,7 @@ public class CoreNodeRenderer {
                 parser.parse(new InputSource(in));
                 for (SaxEvent event : cache.events) {
                     if (event instanceof StartElementEvent) {
-                        event.write(html.contentHandler);
+                        event.write(html);
                     }
                 }
             } catch (IOException | SAXException e) {

--- a/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
@@ -44,6 +44,7 @@ import org.dita.dost.util.SaxCache.StartElementEvent;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.ext.Locator2Impl;
 import org.xml.sax.helpers.AttributesImpl;
 import org.xml.sax.helpers.XMLFilterImpl;
 
@@ -384,7 +385,7 @@ public class CoreNodeRenderer {
             } else {
                 atts.add(ATTRIBUTE_NAME_SPECIALIZATIONS, "@props/audience @props/deliveryTarget @props/otherprops @props/platform @props/product");
             }
-            html.startElement(ELEMENT_NAME_DITA, atts.build());
+            html.startElement(node, ELEMENT_NAME_DITA, atts.build());
         }
         context.renderChildren(node);
         if (isCompound) {
@@ -412,7 +413,7 @@ public class CoreNodeRenderer {
         if (node.getTag().toString().equals("include")) {
             final AttributesBuilder atts = new AttributesBuilder(REQUIRED_CLEANUP_ATTS)
                     .add(ATTRIBUTE_NAME_CONREF, node.getParameters().toString());
-            html.startElement(TOPIC_REQUIRED_CLEANUP, atts.build());
+            html.startElement(node, TOPIC_REQUIRED_CLEANUP, atts.build());
             html.endElement();
         }
     }
@@ -421,7 +422,7 @@ public class CoreNodeRenderer {
         if (node.getChars().charAt(0) == '<') {
             final AttributesBuilder atts = getLinkAttributes(node.getText().toString());
 
-            html.startElement(TOPIC_XREF, getInlineAttributes(node, atts.build()));
+            html.startElement(node, TOPIC_XREF, getInlineAttributes(node, atts.build()));
             html.characters(node.getText().toString());
             html.endElement();
         } else {
@@ -441,7 +442,7 @@ public class CoreNodeRenderer {
                     .add(ATTRIBUTE_NAME_TYPE, "fn")
                     .add(ATTRIBUTE_NAME_HREF, String.format("#%s/%s", lastId, id))
                     .build();
-            html.startElement(TOPIC_XREF, atts);
+            html.startElement(node, TOPIC_XREF, atts);
             html.endElement();
         } else {
             footnotes.add(id);
@@ -449,7 +450,7 @@ public class CoreNodeRenderer {
                     .add("callout", callout)
                     .add(ATTRIBUTE_NAME_ID, id)
                     .build();
-            html.startElement(TOPIC_FN, atts);
+            html.startElement(node, TOPIC_FN, atts);
             Node child = node.getFootnoteBlock().getFirstChild();
             while (child != null) {
                 context.renderChildren(child);
@@ -509,7 +510,7 @@ public class CoreNodeRenderer {
     }
 
     private void render(final DefinitionList node, final NodeRendererContext context, final SaxWriter html) {
-        html.startElement(TOPIC_DL, getAttributesFromAttributesNode(node, DL_ATTS));
+        html.startElement(node, TOPIC_DL, getAttributesFromAttributesNode(node, DL_ATTS));
         DitaClass previous = null;
 //        for (final Node child : node.getChildren()) {
 //            if (previous == null) {
@@ -530,10 +531,10 @@ public class CoreNodeRenderer {
 
     private void render(final DefinitionTerm node, final NodeRendererContext context, final SaxWriter html) {
         if (node.getPrevious() == null || !(node.getPrevious() instanceof DefinitionTerm)) {
-            html.startElement(TOPIC_DLENTRY, DLENTRY_ATTS);
+            html.startElement(node, TOPIC_DLENTRY, DLENTRY_ATTS);
         }
 //        printTag(node, context, html, TOPIC_DT, DT_ATTS);
-        html.startElement(TOPIC_DT, DT_ATTS);
+        html.startElement(node, TOPIC_DT, DT_ATTS);
         Node child = node.getFirstChild();
         while (child != null) {
             Node next = child.getNext();
@@ -567,13 +568,13 @@ public class CoreNodeRenderer {
     private void writeImage(Image node, final String title, final String alt, final AttributesBuilder atts,
                             final NodeRendererContext context, SaxWriter html) {
         if (!title.isEmpty()) {
-            html.startElement(TOPIC_FIG, FIG_ATTS);
-            html.startElement(TOPIC_TITLE, TITLE_ATTS);
+            html.startElement(node, TOPIC_FIG, FIG_ATTS);
+            html.startElement(node, TOPIC_TITLE, TITLE_ATTS);
             html.characters(title);
             html.endElement();
-            html.startElement(TOPIC_IMAGE, atts.build());
+            html.startElement(node, TOPIC_IMAGE, atts.build());
             if (hasChildren(node)) {
-                html.startElement(TOPIC_ALT, ALT_ATTS);
+                html.startElement(node, TOPIC_ALT, ALT_ATTS);
                 if (alt != null) {
                     html.characters(alt);
                 } else {
@@ -587,9 +588,9 @@ public class CoreNodeRenderer {
             if (onlyImageChild) {
                 atts.add("placement", "break");
             }
-            html.startElement(TOPIC_IMAGE, atts.build());
+            html.startElement(node, TOPIC_IMAGE, atts.build());
             if (hasChildren(node)) {
-                html.startElement(TOPIC_ALT, ALT_ATTS);
+                html.startElement(node, TOPIC_ALT, ALT_ATTS);
                 if (alt != null) {
                     html.characters(alt);
                 } else {
@@ -604,13 +605,13 @@ public class CoreNodeRenderer {
     private void writeImage(ImageRef node, final String title, final String alt, final AttributesBuilder atts,
                             final NodeRendererContext context, SaxWriter html) {
         if (!title.isEmpty()) {
-            html.startElement(TOPIC_FIG, FIG_ATTS);
-            html.startElement(TOPIC_TITLE, TITLE_ATTS);
+            html.startElement(node, TOPIC_FIG, FIG_ATTS);
+            html.startElement(node, TOPIC_TITLE, TITLE_ATTS);
             html.characters(title);
             html.endElement();
-            html.startElement(TOPIC_IMAGE, atts.build());
+            html.startElement(node, TOPIC_IMAGE, atts.build());
             if (hasChildren(node)) {
-                html.startElement(TOPIC_ALT, ALT_ATTS);
+                html.startElement(node, TOPIC_ALT, ALT_ATTS);
                 if (alt != null) {
                     html.characters(alt);
                 } else {
@@ -624,9 +625,9 @@ public class CoreNodeRenderer {
             if (onlyImageChild) {
                 atts.add("placement", "break");
             }
-            html.startElement(TOPIC_IMAGE, atts.build());
+            html.startElement(node, TOPIC_IMAGE, atts.build());
             if (hasChildren(node)) {
-                html.startElement(TOPIC_ALT, ALT_ATTS);
+                html.startElement(node, TOPIC_ALT, ALT_ATTS);
                 if (alt != null) {
                     html.characters(alt);
                 } else {
@@ -735,9 +736,9 @@ public class CoreNodeRenderer {
                     atts.add("outputclass", String.join(" ", classes));
                 }
             }
-            html.startElement(cls, atts.build());
+            html.startElement(node, cls, atts.build());
             inSection = true;
-            html.startElement(TOPIC_TITLE, TITLE_ATTS);
+            html.startElement(node, TOPIC_TITLE, TITLE_ATTS);
             context.renderChildren(node);
             html.endElement(); // title
         } else {
@@ -768,24 +769,24 @@ public class CoreNodeRenderer {
                     atts.add(attr.getKey(), attr.getValue());
                 }
             }
-            html.startElement(TOPIC_TOPIC, atts.build());
-            html.startElement(TOPIC_TITLE, TITLE_ATTS);
+            html.startElement(node, TOPIC_TOPIC, atts.build());
+            html.startElement(node, TOPIC_TITLE, TITLE_ATTS);
             context.renderChildren(node);
             html.endElement(); // title
             if (shortdescParagraph && node.getNext() instanceof Paragraph) {
-                html.startElement(TOPIC_SHORTDESC, SHORTDESC_ATTS);
+                html.startElement(node.getNext(), TOPIC_SHORTDESC, SHORTDESC_ATTS);
                 context.renderChildren(node.getNext());
                 html.endElement(); // shortdesc
             }
             if (node.getLevel() == 1) {
                 final Node firstChild = node.getDocument().getFirstChild();
                 if (firstChild instanceof YamlFrontMatterBlock) {
-                    html.startElement(TOPIC_PROLOG, PROLOG_ATTS);
+                    html.startElement(firstChild, TOPIC_PROLOG, PROLOG_ATTS);
                     metadataSerializer.render((YamlFrontMatterBlock) firstChild, context, html);
                     html.endElement();
                 }
             }
-            html.startElement(TOPIC_BODY, BODY_ATTS);
+            html.startElement(node, TOPIC_BODY, BODY_ATTS);
         }
     }
 
@@ -820,7 +821,7 @@ public class CoreNodeRenderer {
     }
 
     private void outputMetadata(Map<String, Object> documentMetadata, SaxWriter html) {
-        html.startElement(TOPIC_PROLOG, PROLOG_ATTS);
+        html.startElement(null, TOPIC_PROLOG, PROLOG_ATTS);
 //        metadataSerializer.write(documentMetadata);
         html.endElement();
     }
@@ -943,7 +944,7 @@ public class CoreNodeRenderer {
         final AttributesBuilder atts = getLinkAttributes("mailto:" + node.getText());
         atts.add(ATTRIBUTE_NAME_FORMAT, "email");
 
-        html.startElement(TOPIC_XREF, getInlineAttributes(node, atts.build()));
+        html.startElement(node, TOPIC_XREF, getInlineAttributes(node, atts.build()));
         context.renderChildren(node);
         html.endElement();
     }
@@ -1044,7 +1045,7 @@ public class CoreNodeRenderer {
             if (onlyImageChild) {
                 atts.add("placement", "break");
             }
-            html.startElement(TOPIC_IMAGE, getInlineAttributes(node, atts.build()));
+            html.startElement(node, TOPIC_IMAGE, getInlineAttributes(node, atts.build()));
 //            if (node.getReference() != null) {
 //                context.renderChildren(node);
 //            }
@@ -1066,14 +1067,14 @@ public class CoreNodeRenderer {
         if (refNode == null) { // "fake" reference link
             final AttributesBuilder atts = new AttributesBuilder(XREF_ATTS)
                     .add(ATTRIBUTE_NAME_KEYREF, key);
-            html.startElement(TOPIC_XREF, atts.build());
+            html.startElement(node, TOPIC_XREF, atts.build());
             if (!node.getText().toString().isEmpty()) {
                 html.characters(node.getText().toString());
             }
             html.endElement();
         } else {
             final AttributesBuilder atts = getLinkAttributes(refNode.getUrl().toString());
-            html.startElement(TOPIC_XREF, atts.build());
+            html.startElement(node, TOPIC_XREF, atts.build());
             if (!refNode.getTitle().toString().isEmpty()) {
                 html.characters(refNode.getTitle().toString());
             } else {
@@ -1097,7 +1098,7 @@ public class CoreNodeRenderer {
 //            html.endElement();
 //        } else {
         final AttributesBuilder atts = getLinkAttributes(node.getUrl().toString());
-        html.startElement(TOPIC_XREF, getInlineAttributes(node, atts.build()));
+        html.startElement(node, TOPIC_XREF, getInlineAttributes(node, atts.build()));
 //            if (!refNode.getTitle().toString().isEmpty()) {
 //                html.characters(refNode.toString());
 //            } else {
@@ -1218,7 +1219,7 @@ public class CoreNodeRenderer {
             atts.add(ATTRIBUTE_NAME_NAMEST, COLUMN_NAME_COL + Integer.toString(currentTableColumn + 1));
             atts.add(ATTRIBUTE_NAME_NAMEEND, COLUMN_NAME_COL + Integer.toString(currentTableColumn + node.getSpan()));
         }
-        html.startElement(TOPIC_ENTRY, atts.build());
+        html.startElement(node, TOPIC_ENTRY, atts.build());
         context.renderChildren(node);
         html.endElement();
 
@@ -1260,10 +1261,10 @@ public class CoreNodeRenderer {
         } else {
             tableAtts = TABLE_ATTS;
         }
-        html.startElement(TOPIC_TABLE, tableAtts);
+        html.startElement(node, TOPIC_TABLE, tableAtts);
         for (final Node child : node.getChildren()) {
             if (child instanceof TableCaption) {
-                html.startElement(TOPIC_TITLE, TITLE_ATTS);
+                html.startElement(child, TOPIC_TITLE, TITLE_ATTS);
                 context.renderChildren((TableCaption) child);
                 html.endElement();
 //                render((TableCaption) child, context, html);
@@ -1273,7 +1274,7 @@ public class CoreNodeRenderer {
         final Attributes atts = new AttributesBuilder(TGROUP_ATTS)
                 .add(ATTRIBUTE_NAME_COLS, Integer.toString(maxCols))
                 .build();
-        html.startElement(TOPIC_TGROUP, atts);
+        html.startElement(node, TOPIC_TGROUP, atts);
 
         for (int i = 0; i < maxCols; i++) {
             final AttributesBuilder catts = new AttributesBuilder(COLSPEC_ATTS)
@@ -1289,7 +1290,7 @@ public class CoreNodeRenderer {
 //                    catts.add(ATTRIBUTE_NAME_ALIGN, "left");
 //                    break;
 //            }
-            html.startElement(TOPIC_COLSPEC, catts.build());
+            html.startElement(node, TOPIC_COLSPEC, catts.build());
             html.endElement(); // colspec
         }
 
@@ -1361,10 +1362,10 @@ public class CoreNodeRenderer {
         } else {
             tableAtts = SIMPLETABLE_ATTS;
         }
-        html.startElement(TOPIC_SIMPLETABLE, tableAtts);
+        html.startElement(node, TOPIC_SIMPLETABLE, tableAtts);
         for (final Node child : node.getChildren()) {
             if (child instanceof TableCaption) {
-                html.startElement(TOPIC_TITLE, TITLE_ATTS);
+                html.startElement(child, TOPIC_TITLE, TITLE_ATTS);
                 context.renderChildren((TableCaption) child);
                 html.endElement();
 //                render((TableCaption) child, context, html);
@@ -1484,9 +1485,9 @@ public class CoreNodeRenderer {
 //            atts.add(ATTRIBUTE_NAME_NAMEEND, COLUMN_NAME_COL + Integer.toString(currentTableColumn + node.getSpan()));
             atts.add(ATTRIBUTE_NAME_COLSPAN, Integer.toString(node.getSpan()));
         }
-        html.startElement(TOPIC_STENTRY, atts.build());
+        html.startElement(node, TOPIC_STENTRY, atts.build());
         if (isInline(node.getFirstChild())) {
-            html.startElement(TOPIC_P, P_ATTS);
+            html.startElement(node, TOPIC_P, P_ATTS);
             context.renderChildren(node);
             html.endElement();
         } else {
@@ -1523,7 +1524,7 @@ public class CoreNodeRenderer {
 //                atts.add("outputclass", String.join(" ", metadata.classes));
 //            }
 //        }
-        html.startElement(lwDita ? TOPIC_PRE : PR_D_CODEBLOCK, atts.build());
+        html.startElement(node, lwDita ? TOPIC_PRE : PR_D_CODEBLOCK, atts.build());
         String text = node.getChars().toString();
         if (text.endsWith("\n")) {
             text = text.substring(0, text.length() - 1);
@@ -1550,10 +1551,10 @@ public class CoreNodeRenderer {
 //                atts.add("outputclass", String.join(" ", metadata.classes));
 //            }
 //        }
-        html.startElement(lwDita ? TOPIC_PRE : PR_D_CODEBLOCK, atts.build());
+        html.startElement(node, lwDita ? TOPIC_PRE : PR_D_CODEBLOCK, atts.build());
         // FIXME: For compatibility with HTML pre/code, should be removed
         if (lwDita) {
-            html.startElement(HI_D_TT, TT_ATTS);
+            html.startElement(node, HI_D_TT, TT_ATTS);
         }
         String text = node.getContentChars().toString();
         if (text.endsWith("\n")) {
@@ -1611,10 +1612,10 @@ public class CoreNodeRenderer {
             }
         }
 
-        html.startElement(lwDita ? TOPIC_PRE : PR_D_CODEBLOCK, atts.build());
+        html.startElement(node, lwDita ? TOPIC_PRE : PR_D_CODEBLOCK, atts.build());
         // FIXME: For compatibility with HTML pre/code, should be removed
         if (lwDita) {
-            html.startElement(HI_D_TT, TT_ATTS);
+            html.startElement(node, HI_D_TT, TT_ATTS);
         }
         String text = node.getContentChars().normalizeEOL();
         if (text.endsWith("\n")) {
@@ -1724,13 +1725,13 @@ public class CoreNodeRenderer {
 //    }
 
     private void printTag(Text node, NodeRendererContext context, SaxWriter html, final DitaClass tag, final Attributes atts) {
-        html.startElement(tag, atts);
+        html.startElement(node, tag, atts);
         html.characters(node.getChars().toString());
         html.endElement();
     }
 
     private void printTag(Node node, NodeRendererContext context, SaxWriter html, final DitaClass tag, final Attributes atts) {
-        html.startElement(tag, atts);
+        html.startElement(node, tag, atts);
         context.renderChildren(node);
         html.endElement();
     }
@@ -1829,7 +1830,7 @@ public class CoreNodeRenderer {
                 if (expansion != null && !expansion.isEmpty()) {
                     atts.add(ATTRIBUTE_NAME_OTHERPROPS, expansion);
                 }
-                html.startElement(TOPIC_PH, atts.build());
+                html.startElement(null, TOPIC_PH, atts.build());
                 html.characters(abbr);
                 html.endElement();
                 ix = sx + abbr.length();
@@ -1839,4 +1840,12 @@ public class CoreNodeRenderer {
             html.characters(string);
         }
     }
+//
+//    private void setLocation(Node node, NodeRendererContext context) {
+//        final Locator2Impl locator = context.getLocator();
+//        if (locator != null) {
+//            locator.setLineNumber(node.getLineNumber() + 1);
+//            locator.setColumnNumber(node.getStartOffset());
+//        }
+//    }
 }

--- a/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
@@ -843,6 +843,9 @@ public class CoreNodeRenderer {
                 .replaceAll("\\s+", "_");
     }
 
+    /**
+     * Render HTML block into DITA.
+     */
     private void render(final HtmlBlock node, final NodeRendererContext context, final SaxWriter html) {
         final String text = node.getChars().toString();
         final FragmentContentHandler fragmentFilter = new FragmentContentHandler();
@@ -863,6 +866,11 @@ public class CoreNodeRenderer {
         }
     }
 
+    /**
+     * Render inline HTML start or end tag. Start tags may contain attributes.
+     *
+     * @TODO Parse directly without HtmlParser, especially end tags, and map to DITA with a mapping table in this class.
+     */
     private void render(final HtmlInline node, final NodeRendererContext context, final SaxWriter html) {
         final String text = node.getChars().toString();
         final CacheContentHandler cache = new CacheContentHandler();
@@ -916,25 +924,25 @@ public class CoreNodeRenderer {
         }
     }
 
-    private StartElementEvent parseHtmlInline(final HtmlInline node) {
-        final List<StartElementEvent> events = new ArrayList<>();
-        final HtmlParser parser = new HtmlParser(XmlViolationPolicy.ALLOW);
-        parser.setContentHandler(new XMLFilterImpl() {
-            @Override
-            public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
-                events.add(new StartElementEvent(uri, localName, qName, atts));
-            }
-        });
-        try (final StringReader in = new StringReader(node.getChars().toString())) {
-            parser.parse(new InputSource(in));
-        } catch (IOException | SAXException e) {
-            throw new ParseException("Failed to parse HTML: " + e.getMessage(), e);
-        }
-        if (events.isEmpty()) {
-            return null;
-        }
-        return events.get(0);
-    }
+//    private StartElementEvent parseHtmlInline(final HtmlInline node) {
+//        final List<StartElementEvent> events = new ArrayList<>();
+//        final HtmlParser parser = new HtmlParser(XmlViolationPolicy.ALLOW);
+//        parser.setContentHandler(new XMLFilterImpl() {
+//            @Override
+//            public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
+//                events.add(new StartElementEvent(uri, localName, qName, atts));
+//            }
+//        });
+//        try (final StringReader in = new StringReader(node.getChars().toString())) {
+//            parser.parse(new InputSource(in));
+//        } catch (IOException | SAXException e) {
+//            throw new ParseException("Failed to parse HTML: " + e.getMessage(), e);
+//        }
+//        if (events.isEmpty()) {
+//            return null;
+//        }
+//        return events.get(0);
+//    }
 
     private void render(final ListItem node, final NodeRendererContext context, final SaxWriter html) {
         printTag(node, context, html, TOPIC_LI, LI_ATTS);
@@ -1673,6 +1681,7 @@ public class CoreNodeRenderer {
         html.processingInstruction("linebreak", null);
     }
 
+    /** Map HTML entity to Unicode character. */
     private void render(final HtmlEntity node, final NodeRendererContext context, final SaxWriter html) {
         final BasedSequence chars = node.getChars();
         final String name = chars.subSequence(1, chars.length() - 1).toString().toLowerCase();

--- a/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
@@ -865,6 +865,7 @@ public class CoreNodeRenderer {
         } catch (IOException | SAXException e) {
             throw new ParseException("Failed to parse HTML: " + e.getMessage(), e);
         }
+        html.setDocumentLocator();
     }
 
     /**
@@ -909,6 +910,7 @@ public class CoreNodeRenderer {
                 throw new ParseException("Failed to parse HTML: " + e.getMessage(), e);
             }
         }
+        html.setDocumentLocator();
     }
 
     private static class CacheContentHandler extends XMLFilterImpl {

--- a/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/CoreNodeRenderer.java
@@ -860,6 +860,7 @@ public class CoreNodeRenderer {
         final HtmlParser parser = new HtmlParser();
         parser.setContentHandler(h);
         try {
+            html.setLocation(node);
             parser.parse(new InputSource(new StringReader(text)));
         } catch (IOException | SAXException e) {
             throw new ParseException("Failed to parse HTML: " + e.getMessage(), e);
@@ -883,6 +884,7 @@ public class CoreNodeRenderer {
         h.setResult(new SAXResult(cache));
         final HtmlParser parser = new HtmlParser(XmlViolationPolicy.ALLOW);
         parser.setContentHandler(h);
+        html.setLocation(node);
         if (text.startsWith("</")) {
             final String data = text.replaceAll("/", "") + text;
             try (final StringReader in = new StringReader(data)) {

--- a/src/main/resources/specialize.xsl
+++ b/src/main/resources/specialize.xsl
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Deprecated -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:x="https://github.com/jelovirt/dita-ot-markdown"

--- a/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
@@ -6,7 +6,6 @@ import org.xml.sax.*;
 import org.xml.sax.helpers.DefaultHandler;
 
 import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;
 import java.io.InputStream;
@@ -107,7 +106,7 @@ public class MDitaReaderTest extends MarkdownReaderTest {
     public void testLocator() throws IOException, SAXException {
         testLocatorParsing(
                 Arrays.asList(
-                        new Event("startDocument", 0, 0),
+                        new Event("startDocument", 1, 1),
 //                        new Event("startPrefixMapping", "ditaarch", 0, 0),
 
                         //# Shortdesc 1:11
@@ -137,7 +136,7 @@ public class MDitaReaderTest extends MarkdownReaderTest {
     public void taskOneStep() throws IOException, SAXException {
         testLocatorParsing(
                 Arrays.asList(
-                        new Event("startDocument", 0, 0),
+                        new Event("startDocument", 1, 1),
 //                        new Event("startPrefixMapping","ditaarch", 0, 0),
 
                         //# Task {.task} 1:14
@@ -252,29 +251,31 @@ public class MDitaReaderTest extends MarkdownReaderTest {
     @Test
     public void test() throws ParserConfigurationException, SAXException, IOException {
         final XMLReader parser = SAXParserFactory.newInstance().newSAXParser().getXMLReader();
-        parser.setContentHandler(new TestContentHandler());
+        parser.setContentHandler(new DefaultHandler() {
+            private Locator locator;
+
+            @Override
+            public void setDocumentLocator(Locator locator) {
+                this.locator = locator;
+            }
+
+            @Override
+            public void startDocument() throws SAXException {
+                System.out.printf("start document %d:%d%n", locator.getLineNumber(), locator.getColumnNumber());
+            }
+
+            @Override
+            public void endDocument() throws SAXException {
+                System.out.printf("end document %d:%d%n", locator.getLineNumber(), locator.getColumnNumber());
+            }
+
+            @Override
+            public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+                System.out.printf("start %s %d:%d%n", qName, locator.getLineNumber(), locator.getColumnNumber());
+            }
+        });
         Reader input = new StringReader("<topic>\n  <title>Title</title>\n  <shortdesc>Desc</shortdesc>\n</topic>\n");
         parser.parse(new InputSource(input));
-    }
-
-    private static class TestContentHandler extends DefaultHandler {
-        private Locator locator;
-        @Override
-        public void setDocumentLocator(Locator locator) {
-            this.locator = locator;
-        }
-        @Override
-        public void startDocument() throws SAXException {
-            System.out.printf("start document %d:%d%n", locator.getLineNumber(), locator.getColumnNumber());
-        }
-        @Override
-        public void endDocument() throws SAXException {
-            System.out.printf("end document %d:%d%n", locator.getLineNumber(), locator.getColumnNumber());
-        }
-        @Override
-        public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-            System.out.printf("start %s %d:%d%n", qName, locator.getLineNumber(), locator.getColumnNumber());
-        }
     }
 
 }

--- a/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
@@ -110,24 +110,24 @@ public class MDitaReaderTest extends MarkdownReaderTest {
 //                        new Event("startPrefixMapping", "ditaarch", 0, 0),
 
                         //# Shortdesc 1:11
-                        new Event("startElement", "topic", 1, 11),
-                        new Event("startElement", "title", 1, 11),
-                        new Event("characters", "Shortdesc", 1, 11),
-                        new Event("endElement", "title",1, 11),
+                        new Event("startElement", "topic", 1, 1),
+                        new Event("startElement", "title", 1, 1),
+                        new Event("characters", "Shortdesc", 1, 1),
+                        new Event("endElement", "title",1, 1),
                         //Shortdesc. 3:10
-                        new Event("startElement", "shortdesc", 3, 11),
-                        new Event("characters", "Shortdesc.",3, 11),
-                        new Event("endElement", "shortdesc", 3, 11),
-                        new Event("startElement", "body", 1, 11),
+                        new Event("startElement", "shortdesc", 3, 1),
+                        new Event("characters", "Shortdesc.",3, 1),
+                        new Event("endElement", "shortdesc", 3, 1),
+                        new Event("startElement", "body", 1, 1),
                         // Paragraph. 5:10
-                        new Event("startElement","p", 5, 10),
-                        new Event("characters", "Paragraph.", 5, 10),
-                        new Event("endElement", "p",5, 10),
-                        new Event("endElement", "body", 5, 10),
-                        new Event("endElement", "topic", 5, 10),
+                        new Event("startElement","p", 5, 1),
+                        new Event("characters", "Paragraph.", 5, 1),
+                        new Event("endElement", "p",5, 1),
+                        new Event("endElement", "body", 5, 1),
+                        new Event("endElement", "topic", 5, 1),
 
 //                        new Event("endPrefixMapping", "ditaarch", 5, 10),
-                        new Event("endDocument", 5, 10)
+                        new Event("endDocument", 5, 1)
                 ),
                 "shortdesc.md");
     }
@@ -140,32 +140,32 @@ public class MDitaReaderTest extends MarkdownReaderTest {
 //                        new Event("startPrefixMapping","ditaarch", 0, 0),
 
                         //# Task {.task} 1:14
-                        new Event("startElement","topic", 1, 14),
-                        new Event("startElement", "title", 1, 14),
-                        new Event("characters", "Task {.task}",1, 14),
-                        new Event("endElement", "title",1, 14),
+                        new Event("startElement","topic", 1, 1),
+                        new Event("startElement", "title", 1, 1),
+                        new Event("characters", "Task {.task}",1, 1),
+                        new Event("endElement", "title",1, 1),
                         // Context 3:8
-                        new Event("startElement", "shortdesc", 3, 8),
-                        new Event("characters", "Context",3, 8),
-                        new Event("endElement", "shortdesc",3, 8),
-                        new Event("startElement",  "body",1, 14),
+                        new Event("startElement", "shortdesc", 3, 1),
+                        new Event("characters", "Context",3, 1),
+                        new Event("endElement", "shortdesc",3, 1),
+                        new Event("startElement",  "body",1, 1),
                         // 1.  Command 5:11
-                        new Event("startElement","ol", 5, 23),
-                        new Event("startElement", "li",5, 23),
-                        new Event("startElement", "p",5, 12),
-                        new Event("characters", "Command",5, 12),
-                        new Event("endElement", "p",5, 12),
+                        new Event("startElement","ol", 5, 1),
+                        new Event("startElement", "li",5, 1),
+                        new Event("startElement", "p",5, 5),
+                        new Event("characters", "Command",5, 5),
+                        new Event("endElement", "p",5, 5),
                         //     Info. 7:10
-                        new Event("startElement", "p",7, 10),
-                        new Event("characters", "Info.",7, 10),
-                        new Event("endElement", "p",7, 10),
-                        new Event("endElement", "li",7, 10),
-                        new Event("endElement", "ol", 7, 10),
-                        new Event("endElement", "body",7, 10),
-                        new Event("endElement", "topic",7, 10),
+                        new Event("startElement", "p",7, 5),
+                        new Event("characters", "Info.",7, 5),
+                        new Event("endElement", "p",7, 5),
+                        new Event("endElement", "li",7, 5),
+                        new Event("endElement", "ol", 7, 5),
+                        new Event("endElement", "body",7, 5),
+                        new Event("endElement", "topic",7, 5),
 
 //                        new Event("endPrefixMapping","ditaarch", 7, 10),
-                        new Event("endDocument", 7, 10)
+                        new Event("endDocument", 7, 5)
                 ),
                 "taskOneStep.md");
     }

--- a/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
@@ -2,8 +2,15 @@ package com.elovirta.dita.markdown;
 
 import org.junit.Ignore;
 import org.junit.Test;
-import org.xml.sax.SAXNotRecognizedException;
-import org.xml.sax.SAXNotSupportedException;
+import org.xml.sax.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+
+import static junit.framework.TestCase.assertEquals;
 
 public class MDitaReaderTest extends MarkdownReaderTest {
 
@@ -41,5 +48,115 @@ public class MDitaReaderTest extends MarkdownReaderTest {
     @Test
     public void testGitHubWikiWithYaml() throws Exception {
 //        run("missing_root_header_with_yaml.md");
+    }
+
+    private static class Event {
+        public final String type;
+        public final int line;
+        public final int column;
+
+        private Event(String type, int line, int column) {
+            this.type = type;
+            this.line = line;
+            this.column = column;
+        }
+    }
+
+    @Test
+    public void testLocator() throws IOException, SAXException {
+        final Deque<Event> exp = new ArrayDeque<>(Arrays.asList(
+                new Event("startDocument", 0, 0),
+                new Event("startPrefixMapping", 0, 0),
+
+                //# Shortdesc 1:11
+                new Event("startElement", 1, 0),
+                new Event("startElement", 1, 0),
+                new Event("characters", 1, 0),
+                new Event("endElement", 1, 0),
+                //Shortdesc. 3:10
+                new Event("startElement", 3, 13),
+                new Event("characters", 3, 13),
+                new Event("endElement", 3, 13),
+                new Event("startElement", 1, 0),
+                //Paragraph. 5:14
+                new Event("startElement", 5, 25),
+                new Event("characters", 5, 25),
+                new Event("endElement", 5, 25),
+                new Event("endElement", 5, 25),
+                new Event("endElement", 5, 25),
+
+                new Event("endPrefixMapping", 5, 25),
+                new Event("endDocument", 5, 25)
+        ));
+        final XMLReader r = getReader();
+        r.setContentHandler(new ContentHandler() {
+            Locator locator;
+
+            private void assertEvent(String name) {
+                final Event event = exp.pop();
+                assertEquals(event.type, name);
+                assertEquals(event.line, locator.getLineNumber());
+                assertEquals(event.column, locator.getColumnNumber());
+            }
+
+            @Override
+            public void setDocumentLocator(Locator locator) {
+                this.locator = locator;
+            }
+
+            @Override
+            public void startDocument() throws SAXException {
+                assertEvent("startDocument");
+            }
+
+            @Override
+            public void endDocument() throws SAXException {
+                assertEvent("endDocument");
+            }
+
+            @Override
+            public void startPrefixMapping(String prefix, String uri) throws SAXException {
+                assertEvent("startPrefixMapping");
+            }
+
+            @Override
+            public void endPrefixMapping(String prefix) throws SAXException {
+                assertEvent("endPrefixMapping");
+            }
+
+            @Override
+            public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
+                assertEvent("startElement");
+            }
+
+            @Override
+            public void endElement(String uri, String localName, String qName) throws SAXException {
+                assertEvent("endElement");
+            }
+
+            @Override
+            public void characters(char[] ch, int start, int length) throws SAXException {
+                assertEvent("characters");
+            }
+
+            @Override
+            public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
+                assertEvent("ignorableWhitespace");
+            }
+
+            @Override
+            public void processingInstruction(String target, String data) throws SAXException {
+                assertEvent("processingInstruction");
+            }
+
+            @Override
+            public void skippedEntity(String name) throws SAXException {
+                assertEvent("skippedEntity");
+            }
+        });
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(getSrc() + "shortdesc.md")) {
+            InputSource input = new InputSource(in);
+            r.parse(input);
+        }
     }
 }

--- a/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
@@ -53,109 +53,48 @@ public class MDitaReaderTest extends MarkdownReaderTest {
 //        run("missing_root_header_with_yaml.md");
     }
 
-    private static class Event {
-        public final String type;
-        public final String data;
-        public final int line;
-        public final int column;
-
-        private Event(String type, int line, int column) {
-            this(type, null, line, column);
-        }
-        private Event(String type, String data, int line, int column) {
-            this.type = type;
-            this.data = data;
-            this.line = line;
-            this.column = column;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-
-            Event event = (Event) o;
-
-            if (line != event.line) return false;
-            if (column != event.column) return false;
-            if (!type.equals(event.type)) return false;
-            return Objects.equals(data, event.data);
-        }
-
-        @Override
-        public int hashCode() {
-            int result = type.hashCode();
-            result = 31 * result + (data != null ? data.hashCode() : 0);
-            result = 31 * result + line;
-            result = 31 * result + column;
-            return result;
-        }
-
-        @Override
-        public String toString() {
-            return "Event{" +
-                    "type='" + type + '\'' +
-                    ", data='" + data + '\'' +
-                    ", line=" + line +
-                    ", column=" + column +
-                    '}';
-        }
-    }
-
     @Test
     public void testLocator() throws IOException, SAXException {
         testLocatorParsing(
                 Arrays.asList(
                         new Event("startDocument", 1, 1),
-//                        new Event("startPrefixMapping", "ditaarch", 0, 0),
-
-                        //# Shortdesc 1:11
                         new Event("startElement", "topic", 1, 1),
                         new Event("startElement", "title", 1, 1),
                         new Event("characters", "Shortdesc", 1, 1),
                         new Event("endElement", "title",1, 1),
-                        //Shortdesc. 3:10
                         new Event("startElement", "shortdesc", 3, 1),
                         new Event("characters", "Shortdesc.",3, 1),
                         new Event("endElement", "shortdesc", 3, 1),
                         new Event("startElement", "body", 1, 1),
-                        // Paragraph. 5:10
                         new Event("startElement","p", 5, 1),
                         new Event("characters", "Paragraph.", 5, 1),
                         new Event("endElement", "p",5, 1),
                         new Event("endElement", "body", 5, 1),
                         new Event("endElement", "topic", 5, 1),
-
-//                        new Event("endPrefixMapping", "ditaarch", 5, 10),
                         new Event("endDocument", 5, 1)
                 ),
                 "shortdesc.md");
     }
 
     @Test
+    @Override
     public void taskOneStep() throws IOException, SAXException {
         testLocatorParsing(
                 Arrays.asList(
                         new Event("startDocument", 1, 1),
-//                        new Event("startPrefixMapping","ditaarch", 0, 0),
-
-                        //# Task {.task} 1:14
                         new Event("startElement","topic", 1, 1),
                         new Event("startElement", "title", 1, 1),
                         new Event("characters", "Task {.task}",1, 1),
                         new Event("endElement", "title",1, 1),
-                        // Context 3:8
                         new Event("startElement", "shortdesc", 3, 1),
                         new Event("characters", "Context",3, 1),
                         new Event("endElement", "shortdesc",3, 1),
                         new Event("startElement",  "body",1, 1),
-                        // 1.  Command 5:11
                         new Event("startElement","ol", 5, 1),
                         new Event("startElement", "li",5, 1),
                         new Event("startElement", "p",5, 5),
                         new Event("characters", "Command",5, 5),
                         new Event("endElement", "p",5, 5),
-                        //     Info. 7:10
                         new Event("startElement", "p",7, 5),
                         new Event("characters", "Info.",7, 5),
                         new Event("endElement", "p",7, 5),
@@ -163,119 +102,8 @@ public class MDitaReaderTest extends MarkdownReaderTest {
                         new Event("endElement", "ol", 7, 5),
                         new Event("endElement", "body",7, 5),
                         new Event("endElement", "topic",7, 5),
-
-//                        new Event("endPrefixMapping","ditaarch", 7, 10),
                         new Event("endDocument", 7, 5)
                 ),
                 "taskOneStep.md");
     }
-
-    private void testLocatorParsing(final List<Event> exp, final String file) throws IOException, SAXException {
-        final XMLReader r = getReader();
-        r.setContentHandler(new LocatorContentHandler(new ArrayDeque<>(exp)));
-        try (InputStream in = getClass().getClassLoader().getResourceAsStream(getSrc() + file)) {
-            InputSource input = new InputSource(in);
-            r.parse(input);
-        }
-    }
-
-    private static class LocatorContentHandler implements ContentHandler {
-        private final Deque<Event> exp;
-        private Locator locator;
-
-        private LocatorContentHandler(Deque<Event> exp) {
-            this.exp = exp;
-        }
-
-        private void assertEvent(String name, String data) {
-            assertEquals(exp.pop(), new Event(name, data, locator.getLineNumber(), locator.getColumnNumber()));
-        }
-
-        @Override
-        public void setDocumentLocator(Locator locator) {
-            this.locator = locator;
-        }
-
-        @Override
-        public void startDocument() throws SAXException {
-            assertEvent("startDocument", null);
-        }
-
-        @Override
-        public void endDocument() throws SAXException {
-            assertEvent("endDocument", null);
-        }
-
-        @Override
-        public void startPrefixMapping(String prefix, String uri) throws SAXException {
-//            assertEvent("startPrefixMapping", prefix);
-        }
-
-        @Override
-        public void endPrefixMapping(String prefix) throws SAXException {
-//            assertEvent("endPrefixMapping", prefix);
-        }
-
-        @Override
-        public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
-            assertEvent("startElement", localName);
-        }
-
-        @Override
-        public void endElement(String uri, String localName, String qName) throws SAXException {
-            assertEvent("endElement", localName);
-        }
-
-        @Override
-        public void characters(char[] ch, int start, int length) throws SAXException {
-            assertEvent("characters", new String(ch, start, length));
-        }
-
-        @Override
-        public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
-            assertEvent("ignorableWhitespace", new String(ch, start, length));
-        }
-
-        @Override
-        public void processingInstruction(String target, String data) throws SAXException {
-            assertEvent("processingInstruction", target);
-        }
-
-        @Override
-        public void skippedEntity(String name) throws SAXException {
-            assertEvent("skippedEntity", name);
-        }
-    }
-
-
-    @Test
-    public void test() throws ParserConfigurationException, SAXException, IOException {
-        final XMLReader parser = SAXParserFactory.newInstance().newSAXParser().getXMLReader();
-        parser.setContentHandler(new DefaultHandler() {
-            private Locator locator;
-
-            @Override
-            public void setDocumentLocator(Locator locator) {
-                this.locator = locator;
-            }
-
-            @Override
-            public void startDocument() throws SAXException {
-                System.out.printf("start document %d:%d%n", locator.getLineNumber(), locator.getColumnNumber());
-            }
-
-            @Override
-            public void endDocument() throws SAXException {
-                System.out.printf("end document %d:%d%n", locator.getLineNumber(), locator.getColumnNumber());
-            }
-
-            @Override
-            public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-                System.out.printf("start %s %d:%d%n", qName, locator.getLineNumber(), locator.getColumnNumber());
-            }
-        });
-        Reader input = new StringReader("<topic>\n  <title>Title</title>\n  <shortdesc>Desc</shortdesc>\n</topic>\n");
-        parser.parse(new InputSource(input));
-    }
-
 }

--- a/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
@@ -2,18 +2,10 @@ package com.elovirta.dita.markdown;
 
 import org.junit.Ignore;
 import org.junit.Test;
-import org.xml.sax.*;
-import org.xml.sax.helpers.DefaultHandler;
+import org.xml.sax.SAXException;
 
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.Reader;
-import java.io.StringReader;
-import java.util.*;
-
-import static junit.framework.TestCase.assertEquals;
+import java.util.Arrays;
 
 public class MDitaReaderTest extends MarkdownReaderTest {
 
@@ -54,6 +46,7 @@ public class MDitaReaderTest extends MarkdownReaderTest {
     }
 
     @Test
+    @Override
     public void testLocator() throws IOException, SAXException {
         testLocatorParsing(
                 Arrays.asList(

--- a/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
@@ -3,9 +3,15 @@ package com.elovirta.dita.markdown;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.xml.sax.*;
+import org.xml.sax.helpers.DefaultHandler;
 
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
 import java.util.*;
 
 import static junit.framework.TestCase.assertEquals;
@@ -102,7 +108,7 @@ public class MDitaReaderTest extends MarkdownReaderTest {
         testLocatorParsing(
                 Arrays.asList(
                         new Event("startDocument", 0, 0),
-                        new Event("startPrefixMapping", "ditaarch", 0, 0),
+//                        new Event("startPrefixMapping", "ditaarch", 0, 0),
 
                         //# Shortdesc 1:11
                         new Event("startElement", "topic", 1, 11),
@@ -121,7 +127,7 @@ public class MDitaReaderTest extends MarkdownReaderTest {
                         new Event("endElement", "body", 5, 10),
                         new Event("endElement", "topic", 5, 10),
 
-                        new Event("endPrefixMapping", "ditaarch", 5, 10),
+//                        new Event("endPrefixMapping", "ditaarch", 5, 10),
                         new Event("endDocument", 5, 10)
                 ),
                 "shortdesc.md");
@@ -132,7 +138,7 @@ public class MDitaReaderTest extends MarkdownReaderTest {
         testLocatorParsing(
                 Arrays.asList(
                         new Event("startDocument", 0, 0),
-                        new Event("startPrefixMapping","ditaarch", 0, 0),
+//                        new Event("startPrefixMapping","ditaarch", 0, 0),
 
                         //# Task {.task} 1:14
                         new Event("startElement","topic", 1, 14),
@@ -159,7 +165,7 @@ public class MDitaReaderTest extends MarkdownReaderTest {
                         new Event("endElement", "body",7, 10),
                         new Event("endElement", "topic",7, 10),
 
-                        new Event("endPrefixMapping","ditaarch", 7, 10),
+//                        new Event("endPrefixMapping","ditaarch", 7, 10),
                         new Event("endDocument", 7, 10)
                 ),
                 "taskOneStep.md");
@@ -203,12 +209,12 @@ public class MDitaReaderTest extends MarkdownReaderTest {
 
         @Override
         public void startPrefixMapping(String prefix, String uri) throws SAXException {
-            assertEvent("startPrefixMapping", prefix);
+//            assertEvent("startPrefixMapping", prefix);
         }
 
         @Override
         public void endPrefixMapping(String prefix) throws SAXException {
-            assertEvent("endPrefixMapping", prefix);
+//            assertEvent("endPrefixMapping", prefix);
         }
 
         @Override
@@ -241,4 +247,34 @@ public class MDitaReaderTest extends MarkdownReaderTest {
             assertEvent("skippedEntity", name);
         }
     }
+
+
+    @Test
+    public void test() throws ParserConfigurationException, SAXException, IOException {
+        final XMLReader parser = SAXParserFactory.newInstance().newSAXParser().getXMLReader();
+        parser.setContentHandler(new TestContentHandler());
+        Reader input = new StringReader("<topic>\n  <title>Title</title>\n  <shortdesc>Desc</shortdesc>\n</topic>\n");
+        parser.parse(new InputSource(input));
+    }
+
+    private static class TestContentHandler extends DefaultHandler {
+        private Locator locator;
+        @Override
+        public void setDocumentLocator(Locator locator) {
+            this.locator = locator;
+        }
+        @Override
+        public void startDocument() throws SAXException {
+            System.out.printf("start document %d:%d%n", locator.getLineNumber(), locator.getColumnNumber());
+        }
+        @Override
+        public void endDocument() throws SAXException {
+            System.out.printf("end document %d:%d%n", locator.getLineNumber(), locator.getColumnNumber());
+        }
+        @Override
+        public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+            System.out.printf("start %s %d:%d%n", qName, locator.getLineNumber(), locator.getColumnNumber());
+        }
+    }
+
 }

--- a/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MDitaReaderTest.java
@@ -99,4 +99,9 @@ public class MDitaReaderTest extends MarkdownReaderTest {
                 ),
                 "taskOneStep.md");
     }
+
+    @Test
+    @Override
+    @Ignore
+    public void testHtmlLocator() throws IOException, SAXException {}
 }

--- a/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
@@ -333,9 +333,9 @@ public class MarkdownReaderTest extends AbstractReaderTest {
                         new Event("characters", ".",3, 26),
                         new Event("endElement", "p", 3, 26),
 
-                        new Event("startElement","p", 586, 8),
-                        new Event("characters", "HTML paragraph.", 761, 15),
-                        new Event("endElement", "p",761, 15),
+                        new Event("startElement","p", 5, 1),
+                        new Event("characters", "HTML paragraph.", 5, 1),
+                        new Event("endElement", "p",5, 1),
 
                         new Event("startElement","p", 7, 1),
                         new Event("startElement","video", 7, 1),

--- a/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
@@ -9,6 +9,7 @@ import org.xml.sax.*;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 
@@ -255,69 +256,36 @@ public class MarkdownReaderTest extends AbstractReaderTest {
     }
 
     @Test
-    public void testLocator() throws IOException, SAXException {
-        final XMLReader r = getReader();
-        r.setContentHandler(new ContentHandler() {
-            Locator locator;
-
-            @Override
-            public void setDocumentLocator(Locator locator) {
-                this.locator = locator;
-            }
-
-            @Override
-            public void startDocument() throws SAXException {
-                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
-            }
-
-            @Override
-            public void endDocument() throws SAXException {
-                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
-            }
-
-            @Override
-            public void startPrefixMapping(String prefix, String uri) throws SAXException {
-                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
-            }
-
-            @Override
-            public void endPrefixMapping(String prefix) throws SAXException {
-                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
-            }
-
-            @Override
-            public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
-                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
-            }
-
-            @Override
-            public void endElement(String uri, String localName, String qName) throws SAXException {
-                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
-            }
-
-            @Override
-            public void characters(char[] ch, int start, int length) throws SAXException {
-                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
-            }
-
-            @Override
-            public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
-                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
-            }
-
-            @Override
-            public void processingInstruction(String target, String data) throws SAXException {
-                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
-            }
-
-            @Override
-            public void skippedEntity(String name) throws SAXException {
-                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
-            }
-        });
-        try (InputStream in = getClass().getClassLoader().getResourceAsStream("/" + getSrc() + "shortdesc.md")) {
-            InputSource input = new InputSource(in);
-            r.parse(input);
-        }
+    public void taskOneStep() throws IOException, SAXException {
+        testLocatorParsing(
+            Arrays.asList(
+                    new Event("startDocument", 1, 1),
+                    new Event("startElement","task", 1, 1),
+                    new Event("startElement", "title", 1, 1),
+                    new Event("characters", "Task",1, 1),
+                    new Event("endElement", "title",1, 1),
+                    new Event("startElement",  "taskbody",1, 1),
+                    new Event("startElement", "context", 3, 1),
+                    new Event("startElement", "p", 3, 1),
+                    new Event("characters", "Context",3, 1),
+                    new Event("endElement", "p",3, 1),
+                    new Event("endElement", "context",5, 1),
+                    new Event("startElement","steps", 5, 1),
+                    new Event("startElement", "step",5, 1),
+                    new Event("startElement", "cmd",5, 5),
+                    new Event("characters", "Command",5, 5),
+                    new Event("endElement", "cmd",5, 5),
+                    new Event("startElement", "info",7, 5),
+                    new Event("startElement", "p",7, 5),
+                    new Event("characters", "Info.",7, 5),
+                    new Event("endElement", "p",7, 5),
+                    new Event("endElement", "info",7, 5),
+                    new Event("endElement", "step",7, 5),
+                    new Event("endElement", "steps", 7, 5),
+                    new Event("endElement", "taskbody",7, 5),
+                    new Event("endElement", "task",7, 5),
+                    new Event("endDocument", 7, 5)
+            ),
+            "taskOneStep.md");
     }
 }

--- a/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
@@ -324,21 +324,27 @@ public class MarkdownReaderTest extends AbstractReaderTest {
                         new Event("startElement", "body", 1, 1),
 
                         new Event("startElement", "p", 3, 1),
-                        new Event("characters", "Plain paragraph.",3, 1),
-                        new Event("endElement", "p", 3, 1),
+                        new Event("characters", "Plain ",3, 1),
+                        new Event("startElement", "b", 3, 7),
+                        new Event("startElement", "i", 3, 10),
+                        new Event("characters", "paragraph",3, 10),
+                        new Event("endElement", "i", 3, 22),
+                        new Event("endElement", "b", 3, 26),
+                        new Event("characters", ".",3, 26),
+                        new Event("endElement", "p", 3, 26),
 
                         new Event("startElement","p", 586, 8),
                         new Event("characters", "HTML paragraph.", 761, 15),
                         new Event("endElement", "p",761, 15),
 
-                        new Event("startElement","p", 761, 15),
-                        new Event("startElement","video", 761, 15),
-                        new Event("endElement", "video",761, 15),
-                        new Event("endElement", "p",761, 15),
+                        new Event("startElement","p", 7, 1),
+                        new Event("startElement","video", 7, 1),
+                        new Event("endElement", "video",7, 54),
+                        new Event("endElement", "p",7, 54),
 
-                        new Event("endElement", "body", 761, 15),
-                        new Event("endElement", "topic", 761, 15),
-                        new Event("endDocument", 761, 15)
+                        new Event("endElement", "body", 7, 54),
+                        new Event("endElement", "topic", 7, 54),
+                        new Event("endDocument", 7, 54)
                 ),
                 "html.md");
     }

--- a/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
@@ -1,13 +1,13 @@
 package com.elovirta.dita.markdown;
 
 import com.elovirta.dita.utils.AbstractReaderTest;
-import org.dita.dost.util.SaxCache;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.xml.sax.*;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
 import java.util.Arrays;
 
@@ -253,6 +253,29 @@ public class MarkdownReaderTest extends AbstractReaderTest {
     @Test
     public void testAbbreviation() throws Exception {
         run("abbreviation.md");
+    }
+
+    @Test
+    public void testLocator() throws IOException, SAXException {
+        testLocatorParsing(
+                Arrays.asList(
+                        new Event("startDocument", 1, 1),
+                        new Event("startElement", "topic", 1, 1),
+                        new Event("startElement", "title", 1, 1),
+                        new Event("characters", "Shortdesc", 1, 1),
+                        new Event("endElement", "title",1, 1),
+                        new Event("startElement", "body", 1, 1),
+                        new Event("startElement", "p", 3, 1),
+                        new Event("characters", "Shortdesc.",3, 1),
+                        new Event("endElement", "p", 3, 1),
+                        new Event("startElement","p", 5, 1),
+                        new Event("characters", "Paragraph.", 5, 1),
+                        new Event("endElement", "p",5, 1),
+                        new Event("endElement", "body", 5, 1),
+                        new Event("endElement", "topic", 5, 1),
+                        new Event("endDocument", 5, 1)
+                ),
+                "shortdesc.md");
     }
 
     @Test

--- a/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
@@ -311,4 +311,35 @@ public class MarkdownReaderTest extends AbstractReaderTest {
             ),
             "taskOneStep.md");
     }
+
+    @Test
+    public void testHtmlLocator() throws IOException, SAXException {
+        testLocatorParsing(
+                Arrays.asList(
+                        new Event("startDocument", 1, 1),
+                        new Event("startElement", "topic", 1, 1),
+                        new Event("startElement", "title", 1, 1),
+                        new Event("characters", "HTML Block", 1, 1),
+                        new Event("endElement", "title",1, 1),
+                        new Event("startElement", "body", 1, 1),
+
+                        new Event("startElement", "p", 3, 1),
+                        new Event("characters", "Plain paragraph.",3, 1),
+                        new Event("endElement", "p", 3, 1),
+
+                        new Event("startElement","p", 586, 8),
+                        new Event("characters", "HTML paragraph.", 761, 15),
+                        new Event("endElement", "p",761, 15),
+
+                        new Event("startElement","p", 761, 15),
+                        new Event("startElement","video", 761, 15),
+                        new Event("endElement", "video",761, 15),
+                        new Event("endElement", "p",761, 15),
+
+                        new Event("endElement", "body", 761, 15),
+                        new Event("endElement", "topic", 761, 15),
+                        new Event("endDocument", 761, 15)
+                ),
+                "html.md");
+    }
 }

--- a/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
@@ -1,11 +1,13 @@
 package com.elovirta.dita.markdown;
 
 import com.elovirta.dita.utils.AbstractReaderTest;
+import org.dita.dost.util.SaxCache;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.xml.sax.InputSource;
-import org.xml.sax.XMLReader;
+import org.xml.sax.*;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 
 import static org.junit.Assert.assertEquals;
@@ -252,4 +254,70 @@ public class MarkdownReaderTest extends AbstractReaderTest {
         run("abbreviation.md");
     }
 
+    @Test
+    public void testLocator() throws IOException, SAXException {
+        final XMLReader r = getReader();
+        r.setContentHandler(new ContentHandler() {
+            Locator locator;
+
+            @Override
+            public void setDocumentLocator(Locator locator) {
+                this.locator = locator;
+            }
+
+            @Override
+            public void startDocument() throws SAXException {
+                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
+            }
+
+            @Override
+            public void endDocument() throws SAXException {
+                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
+            }
+
+            @Override
+            public void startPrefixMapping(String prefix, String uri) throws SAXException {
+                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
+            }
+
+            @Override
+            public void endPrefixMapping(String prefix) throws SAXException {
+                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
+            }
+
+            @Override
+            public void startElement(String uri, String localName, String qName, Attributes atts) throws SAXException {
+                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
+            }
+
+            @Override
+            public void endElement(String uri, String localName, String qName) throws SAXException {
+                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
+            }
+
+            @Override
+            public void characters(char[] ch, int start, int length) throws SAXException {
+                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
+            }
+
+            @Override
+            public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
+                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
+            }
+
+            @Override
+            public void processingInstruction(String target, String data) throws SAXException {
+                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
+            }
+
+            @Override
+            public void skippedEntity(String name) throws SAXException {
+                System.out.println(locator.getLineNumber() + ":" + locator.getColumnNumber());
+            }
+        });
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream("/" + getSrc() + "shortdesc.md")) {
+            InputSource input = new InputSource(in);
+            r.parse(input);
+        }
+    }
 }

--- a/src/test/resources/dita/html.dita
+++ b/src/test/resources/dita/html.dita
@@ -3,7 +3,7 @@
   id="html-block" ditaarch:DITAArchVersion="2.0">
   <title class="- topic/title ">HTML Block</title>
   <body class="- topic/body ">
-    <p class="- topic/p ">Plain paragraph.</p>
+    <p class="- topic/p ">Plain <b class="+ topic/ph hi-d/b "><i class="+ topic/ph hi-d/i ">paragraph</i></b>.</p>
     <p class="- topic/p ">HTML paragraph.</p>
     <p class="- topic/p "><video class="+ topic/object h5m-d/video " controls="" poster="remote.png" src="remote.mp4"/></p>
   </body>

--- a/src/test/resources/hdita/html.html
+++ b/src/test/resources/hdita/html.html
@@ -2,7 +2,7 @@
 <title>HTML Block</title>
 <article>
   <h1>HTML Block</h1>
-  <p>Plain paragraph.</p>
+  <p>Plain <b><i>paragraph</i></b>.</p>
   <p>HTML paragraph.</p>
   <p><video controls poster="remote.png" src="remote.mp4"></video></p>
 </article>

--- a/src/test/resources/html/html.html
+++ b/src/test/resources/html/html.html
@@ -2,7 +2,7 @@
 <title>HTML Block</title>
 <article>
   <h1>HTML Block</h1>
-  <p>Plain paragraph.</p>
+  <p>Plain <b><i>paragraph</i></b>.</p>
   <p>HTML paragraph.</p>
   <p><video controls poster="remote.png" src="remote.mp4"></video></p>
 </article>

--- a/src/test/resources/markdown/html.md
+++ b/src/test/resources/markdown/html.md
@@ -1,6 +1,6 @@
 # HTML Block
 
-Plain paragraph.
+Plain <b><i>paragraph</i></b>.
 
 <p>HTML paragraph.</p>
 

--- a/src/test/resources/markdown/root.ditamap
+++ b/src/test/resources/markdown/root.ditamap
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE map PUBLIC "-//OASIS//DTD DITA Map//EN" "map.dtd">
+<map>
+  <topicref href="ast.md" format="markdown"/>
+  <topicref href="codeblock.md" format="markdown"/>
+  <topicref href="comment.md" format="markdown"/>
+  <topicref href="concept.md" format="markdown"/>
+  <topicref href="conkeyref.md" format="markdown"/>
+  <topicref href="conref.md" format="markdown"/>
+  <topicref href="dl.md" format="markdown"/>
+  <topicref href="entity.md" format="markdown"/>
+  <topicref href="escape.md" format="markdown"/>
+  <topicref href="footnote.md" format="markdown"/>
+  <topicref href="header.md" format="markdown"/>
+  <topicref href="header_attributes.md" format="markdown"/>
+  <topicref href="html.md" format="markdown"/>
+  <topicref href="image.md" format="markdown"/>
+  <topicref href="inline.md" format="markdown"/>
+  <topicref href="invalid_header.md" format="markdown"/>
+  <topicref href="invalid_section_header.md" format="markdown"/>
+  <topicref href="jekyll.md" format="markdown"/>
+  <topicref href="keyref.md" format="markdown"/>
+  <topicref href="keys.md" format="markdown"/>
+  <topicref href="linebreak.md" format="markdown"/>
+  <topicref href="link.md" format="markdown"/>
+  <topicref href="multiple_top_level.md" format="markdown"/>
+  <topicref href="multiple_top_level_specialized.md" format="markdown"/>
+  <topicref href="nested.md" format="markdown"/>
+  <topicref href="ol.md" format="markdown"/>
+  <topicref href="pandoc_header.md" format="markdown"/>
+  <topicref href="quote.md" format="markdown"/>
+  <topicref href="reference.md" format="markdown"/>
+  <topicref href="short.md" format="markdown"/>
+  <topicref href="shortdesc.md" format="markdown"/>
+  <topicref href="table.md" format="markdown"/>
+  <topicref href="task.md" format="markdown"/>
+  <topicref href="taskOneStep.md" format="markdown"/>
+  <topicref href="test.md" format="markdown"/>
+  <topicref href="testBOM.md" format="markdown"/>
+  <topicref href="testNoBOM.md" format="markdown"/>
+  <topicref href="ul.md" format="markdown"/>
+  <topicref href="yaml.md" format="markdown"/>
+
+</map>

--- a/src/test/resources/xdita/html.dita
+++ b/src/test/resources/xdita/html.dita
@@ -2,7 +2,7 @@
   specializations="(topic hi-d)(topic em-d)"
   id="html-block" ditaarch:DITAArchVersion="2.0">
   <title class="- topic/title ">HTML Block</title>
-  <shortdesc class="- topic/shortdesc ">Plain paragraph.</shortdesc>
+  <shortdesc class="- topic/shortdesc ">Plain <b class="+ topic/ph hi-d/b "><i class="+ topic/ph hi-d/i ">paragraph</i></b>.</shortdesc>
   <body class="- topic/body ">
     <p class="- topic/p ">HTML paragraph.</p>
     <p class="- topic/p "><video class="+ topic/object h5m-d/video " controls="" poster="remote.png" src="remote.mp4"/></p>


### PR DESCRIPTION
Add support for [`Locator`](https://docs.oracle.com/javase/8/docs/api/org/xml/sax/Locator.html) to track source character positions. Because this implementation primarily targets use with DITA-OT, the most important event location to track is the start element event. This will be used to generate `@xtrf` debug attribute.

The `Locator` allows accessing SAX events' location information, specifically where the event ends. That mean if we have XML fragment

```xml
   12345678901234567890
  ---------------------
1| <topic>
2|   <title>Title</title>
3|   <shortdesc>Desc</shortdesc>
4| </topic>
5| 
```
The locations of events will be:

-   start document `1:1`
-  `topic` start element `1:8`
-  `title` start element `2:10`
-  `shortdesc` start element `3:14`

In XML this makes sense, because the parser will read the input stream and emit the event when the next token is encountered. 

Because different Markdown structures don't always have similar start delimiters, mapping line and column location between Markdown and XML isn't completely straight forward. Comparing to previous XML example, if we have Markdown fragment

```
   12345678901234567890
  ---------------------
1| # Title
2|
3| Desc 
4|
```
The locations of synthetic events will be:

-   start document `1:1`
-  `topic` start element `1:2`
-  `title` start element `1:2`
- `shortdesc` start element `3:1`

So effectively, the start element event from XML parser will report the next character after start element, Markdown parsing will report the first character of the content. It's as if the start element was there, but invisible.