### PR TITLE
Add support for ordered list in map

### DIFF
--- a/src/main/java/com/elovirta/dita/markdown/renderer/MapRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/MapRenderer.java
@@ -74,8 +74,8 @@ import static org.dita.dost.util.XMLUtils.AttributesBuilder;
  */
 public class MapRenderer {
 
-    private static final String COLUMN_NAME_COL = "col";
-    private static final String ATTRIBUTE_NAME_COLSPAN = "colspan";
+//    private static final String COLUMN_NAME_COL = "col";
+//    private static final String ATTRIBUTE_NAME_COLSPAN = "colspan";
 
     private static final Attributes MAP_ATTS = new AttributesBuilder()
             .add(ATTRIBUTE_NAME_CLASS, MAP_MAP.toString())
@@ -221,7 +221,7 @@ public class MapRenderer {
         res.add(new NodeRenderingHandler<>(YamlFrontMatterBlock.class, (node, context, html) -> render(node, context, html)));
 //            res.add(new NodeRenderingHandler<>(BlockQuote.class, (node, context, html) -> render(node, context, html)));
         res.add(new NodeRenderingHandler<>(BulletList.class, (node, context, html) -> render(node, context, html)));
-//            res.add(new NodeRenderingHandler<>(Code.class, (node, context, html) -> render(node, context, html)));
+        res.add(new NodeRenderingHandler<>(Code.class, (node, context, html) -> render(node, context, html)));
 //            res.add(new NodeRenderingHandler<>(CodeBlock.class, (node, context, html) -> render(node, context, html)));
         res.add(new NodeRenderingHandler<>(Document.class, (node, context, html) -> render(node, context, html)));
         res.add(new NodeRenderingHandler<>(Emphasis.class, (node, context, html) -> render(node, context, html)));
@@ -850,38 +850,27 @@ public class MapRenderer {
         }
         final LinkRef linkRef = paragraph != null ? (LinkRef) paragraph.getChildOfType(LinkRef.class) : null;
         if (linkRef != null) {
-//            atts.addAll(getLinkAttributes(linkRef.getUrl().toString(), TOPICREF_ATTS).build());
-//            final String text = linkRef.getText().toString();
-//            atts.add("navtitle", text);
-
             final String text = linkRef.getText().toString();
             final String key = linkRef.getReference() != null ? linkRef.getReference().toString() : text;
             final Reference refNode = linkRef.getReferenceNode(linkRef.getDocument());
             if (refNode == null) { // "fake" reference link
                 atts.add(ATTRIBUTE_NAME_KEYREF, key);
-//                html.startElement(linkRef, TOPIC_XREF, atts.build());
                 if (!linkRef.getText().toString().isEmpty()) {
                     atts.add("navtitle", linkRef.getText().toString());
                 }
             } else {
                 atts.addAll(getLinkAttributes(refNode.getUrl().toString(), TOPICREF_ATTS).build());
                 atts.add(ATTRIBUTE_NAME_KEYREF, refNode.getReference().toString());
-//                html.startElement(linkRef, TOPIC_XREF, atts.build());
                 if (!refNode.getTitle().toString().isEmpty()) {
                     atts.add("navtitle", refNode.getTitle().toString());
-//                } else {
-//                    context.renderChildren(linkRef);
                 }
             }
         }
-
-//        html.startElement(node, TOPIC_XREF, );
-//        context.renderChildren(node);
-//        html.endElement();
+        if (node instanceof OrderedListItem) {
+            atts.add("collection-type", "sequence");
+        }
 
         html.startElement(node, MAP_TOPICREF, getInlineAttributes(node, atts.build()));
-//        node.getFirstChildAnyNot(Paragraph.class);
-//        context.renderChildren(node);
         Node child = node.getFirstChild();
         while (child != null) {
             Node next = child.getNext();
@@ -890,7 +879,7 @@ public class MapRenderer {
             }
             child = next;
         }
-        html.endElement(); // topicref
+        html.endElement();
     }
 
     private void render(final MailLink node, final NodeRendererContext context, final SaxWriter html) {
@@ -903,7 +892,7 @@ public class MapRenderer {
     }
 
     private void render(final OrderedList node, final NodeRendererContext context, final SaxWriter html) {
-        printTag(node, context, html, TOPIC_OL, getAttributesFromAttributesNode(node, OL_ATTS));
+        context.renderChildren(node);
     }
 
     private boolean onlyImageChild = false;
@@ -1456,7 +1445,7 @@ public class MapRenderer {
 //            context.renderChildren(node);
 //            html.endElement();
 //        } else {
-            context.renderChildren(node);
+        context.renderChildren(node);
 //        }
         html.endElement();
 

--- a/src/main/java/com/elovirta/dita/markdown/renderer/MapRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/MapRenderer.java
@@ -846,7 +846,9 @@ public class MapRenderer {
         if (link != null) {
             atts.addAll(getLinkAttributes(link.getUrl().toString(), TOPICREF_ATTS).build());
             final String text = link.getText().toString();
-            atts.add("navtitle", text);
+            if (!text.isEmpty()) {
+                atts.add("navtitle", text);
+            }
         }
         final LinkRef linkRef = paragraph != null ? (LinkRef) paragraph.getChildOfType(LinkRef.class) : null;
         if (linkRef != null) {
@@ -855,8 +857,8 @@ public class MapRenderer {
             final Reference refNode = linkRef.getReferenceNode(linkRef.getDocument());
             if (refNode == null) { // "fake" reference link
                 atts.add(ATTRIBUTE_NAME_KEYREF, key);
-                if (!linkRef.getText().toString().isEmpty()) {
-                    atts.add("navtitle", linkRef.getText().toString());
+                if (!text.isEmpty()) {
+                    atts.add("navtitle", text);
                 }
             } else {
                 atts.addAll(getLinkAttributes(refNode.getUrl().toString(), TOPICREF_ATTS).build());

--- a/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
@@ -99,7 +99,9 @@ public class MarkdownReaderTest extends AbstractReaderTest {
     @ParameterizedTest
     @ValueSource(strings = {
             "map.md",
+            "map_ol.md",
             "map_reltable.md",
+            "map_title.md",
             "map_without_title.md",
             "map_yaml.md",
     })

--- a/src/test/resources/dita/link.dita
+++ b/src/test/resources/dita/link.dita
@@ -26,6 +26,9 @@
         scope="external">External</xref>
     </p>
     <p class="- topic/p ">
+      <xref class="- topic/xref " href="concept.md" format="markdown"></xref>
+    </p>
+    <p class="- topic/p ">
       <xref class="- topic/xref " keyref="key"/>
     </p>
     <p class="- topic/p ">

--- a/src/test/resources/dita/map.dita
+++ b/src/test/resources/dita/map.dita
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " id="title"
-  specializations="@props/audience @props/deliveryTarget @props/otherprops @props/platform @props/product"
-  ditaarch:DITAArchVersion="2.0">
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " ditaarch:DITAArchVersion="2.0"
+     id="title"
+     specializations="@props/audience @props/deliveryTarget @props/otherprops @props/platform @props/product">
   <title class="- topic/title ">Title</title>
   <topicmeta class="- map/topicmeta "/>
   <topicref class="- map/topicref " format="markdown" href="topic-a.md" navtitle="A">
-    <topicref class="- map/topicref " format="markdown" href="topic-a-1.md" navtitle="A.1"/>
+    <topicref class="- map/topicref " format="markdown" href="topic-a-1.md"/>
   </topicref>
   <topicref class="- map/topicref " format="markdown" href="topic-b.md" navtitle="B">
     <topicref class="- map/topicref " format="markdown" href="topic-b-1.md" navtitle="B.1"/>

--- a/src/test/resources/dita/map_ol.dita
+++ b/src/test/resources/dita/map_ol.dita
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " ditaarch:DITAArchVersion="2.0"
+     id="title"
+     specializations="@props/audience @props/deliveryTarget @props/otherprops @props/platform @props/product">
+  <title class="- topic/title ">Title</title>
+  <topicmeta class="- map/topicmeta "/>
+  <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-1.md" navtitle="1">
+    <topicref class="- map/topicref " format="markdown" href="topic-1-a.md" navtitle="1.A">
+      <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-1-a-1.md"
+                navtitle="1.A.1"/>
+    </topicref>
+  </topicref>
+  <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-2.md" navtitle="2">
+    <topicref class="- map/topicref " format="markdown" href="topic-2-a.md" navtitle="2.A">
+      <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-2-a-1.md"
+                navtitle="2.A.1"/>
+    </topicref>
+  </topicref>
+  <topicref class="- map/topicref " format="markdown" href="topic-a.md" navtitle="A">
+    <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-a-1.md" navtitle="A.1">
+      <topicref class="- map/topicref " format="markdown" href="topic-a-1-a.md" navtitle="A.1.A"/>
+    </topicref>
+  </topicref>
+  <topicref class="- map/topicref " format="markdown" href="topic-b.md" navtitle="B">
+    <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-b-1.md" navtitle="B.1">
+      <topicref class="- map/topicref " format="markdown" href="topic-b-1-a.md" navtitle="B.1.A"/>
+    </topicref>
+  </topicref>
+</map>

--- a/src/test/resources/dita/map_title.dita
+++ b/src/test/resources/dita/map_title.dita
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " ditaarch:DITAArchVersion="2.0"
+     id="title-alt-italic-bold-code"
+     specializations="@props/audience @props/deliveryTarget @props/otherprops @props/platform @props/product">
+  <title class="- topic/title ">Title
+    <image class="- topic/image " href="test.jpg">
+      <alt class="- topic/alt ">Alt</alt>
+    </image>
+    <i class="+ topic/ph hi-d/i ">italic</i>
+    <b class="+ topic/ph hi-d/b ">bold</b>
+    <codeph class="+ topic/ph pr-d/codeph ">code</codeph>
+  </title>
+  <topicmeta class="- map/topicmeta "/>
+  <topicref class="- map/topicref " format="markdown" href="topic.md" navtitle="key"/>
+  <keydef class="+ map/topicref mapgroup-d/keydef " format="markdown" href="topic.md" keys="key"/>
+</map>

--- a/src/test/resources/hdita/link.html
+++ b/src/test/resources/hdita/link.html
@@ -24,6 +24,9 @@
     <a href="http://www.example.com/test.html">External</a>
   </p>
   <p>
+    <a href="concept.md"></a>
+  </p>
+  <p>
     <a data-keyref="key"></a>
   </p>
   <p>

--- a/src/test/resources/html/link.html
+++ b/src/test/resources/html/link.html
@@ -24,6 +24,9 @@
     <a href="http://www.example.com/test.html">External</a>
   </p>
   <p>
+    <a href="concept.md"></a>
+  </p>
+  <p>
     <a data-keyref="key"></a>
   </p>
   <p>

--- a/src/test/resources/markdown/link.md
+++ b/src/test/resources/markdown/link.md
@@ -15,6 +15,8 @@ Links
 
 [External](http://www.example.com/test.html)
 
+[](concept.md)
+
 [key]
 
 <address@example.com>

--- a/src/test/resources/markdown/map.md
+++ b/src/test/resources/markdown/map.md
@@ -5,7 +5,7 @@ $schema: urn:oasis:names:tc:dita:xsd:map.xsd
 # Title
 
 * [A](topic-a.md)
-  * [A.1](topic-a-1.md)
+  * [](topic-a-1.md)
 * [B](topic-b.md)
   * [B.1](topic-b-1.md)
 * [key-a]

--- a/src/test/resources/markdown/map_ol.md
+++ b/src/test/resources/markdown/map_ol.md
@@ -1,0 +1,18 @@
+---
+$schema: urn:oasis:names:tc:dita:xsd:map.xsd
+---
+
+# Title
+
+1. [1](topic-1.md)
+   * [1.A](topic-1-a.md)
+     1.  [1.A.1](topic-1-a-1.md)
+2. [2](topic-2.md)
+   * [2.A](topic-2-a.md)
+     1.  [2.A.1](topic-2-a-1.md)
+* [A](topic-a.md)
+  1.  [A.1](topic-a-1.md)
+      * [A.1.A](topic-a-1-a.md)
+* [B](topic-b.md)
+  1. [B.1](topic-b-1.md)
+     * [B.1.A](topic-b-1-a.md)

--- a/src/test/resources/markdown/map_title.md
+++ b/src/test/resources/markdown/map_title.md
@@ -1,0 +1,9 @@
+---
+$schema: urn:oasis:names:tc:dita:xsd:map.xsd
+---
+
+# Title ![Alt](test.jpg) _italic_ **bold** `code` 
+
+* [key](topic.md)
+
+[key]: topic.md

--- a/src/test/resources/xdita/link.dita
+++ b/src/test/resources/xdita/link.dita
@@ -28,6 +28,9 @@
         scope="external">External</xref>
     </p>
     <p class="- topic/p ">
+      <xref class="- topic/xref " href="concept.md" format="markdown"></xref>
+    </p>
+    <p class="- topic/p ">
       <xref class="- topic/xref " keyref="key"/>
     </p>
     <p class="- topic/p ">


### PR DESCRIPTION
Add support for ordered lists in maps.

```markdown
---
$schema: urn:oasis:names:tc:dita:xsd:map.xsd
---

1.  [Topic A](topic-a.md)
2.  [Topic B](topic-b.md)
```

This will create `topicref` elements with `collection-type="sequence"`.
```xml
<map>
  <topicref href="topic-a.dita" navtitle="Topic A" collection-type="sequence"/>
  <topicref href="topic-b.dita" navtitle="Topic B" collection-type="sequence"/>
</map>
```