### PR TITLE
Convert <?linefeed?> to line feed in HTML5 and PDF

### DIFF
--- a/src/main/plugin.xml
+++ b/src/main/plugin.xml
@@ -39,6 +39,8 @@
   <feature extension="dita.conductor.lib.import" file="lib/flexmark-util-misc-0.64.0.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/flexmark-util-visitor-0.64.0.jar"/>
   <feature extension="dita.conductor.lib.import" file="lib/autolink-0.6.0.jar"/>
+  <feature extension="dita.xsl.html5" file="xsl/linebreak2html5.xsl"/>
+  <feature extension="dita.xsl.xslfo" file="xsl/linebreak2fo.xsl"/>
   <feature extension="dita.parser">
     <parser format="markdown" class="com.elovirta.dita.markdown.MarkdownReader"/>
     <parser format="md" class="com.elovirta.dita.markdown.MarkdownReader"/>

--- a/src/main/resources/linebreak2fo.xsl
+++ b/src/main/resources/linebreak2fo.xsl
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:fo="http://www.w3.org/1999/XSL/Format">
+
+  <xsl:template match="processing-instruction('linebreak')">
+    <fo:block line-height="0pt"/>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/src/main/resources/linebreak2html5.xsl
+++ b/src/main/resources/linebreak2html5.xsl
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:template match="processing-instruction('linebreak')">
+    <br/>
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
For hard line break `<?linebreak?>` generated from Markdown input, support HTML5 and PDF output.

Fixes #93