### PR TITLE
Support topichead in Markdown map

### DIFF
--- a/src/main/java/com/elovirta/dita/markdown/renderer/MapRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/MapRenderer.java
@@ -447,8 +447,13 @@ public class MapRenderer extends AbstractRenderer {
         }
       }
     } else {
-      name = MAPGROUP_D_TOPICHEAD;
-      atts = new AttributesBuilder(TOPICHEAD_ATTS);
+      if (mditaCoreProfile || mditaExtendedProfile) {
+        name = MAP_TOPICREF;
+        atts = new AttributesBuilder(TOPICREF_ATTS);
+      } else {
+        name = MAPGROUP_D_TOPICHEAD;
+        atts = new AttributesBuilder(TOPICHEAD_ATTS);
+      }
       final StringBuilder buf = new StringBuilder();
       Node child = paragraph.getFirstChild();
       while (child != null) {

--- a/src/main/java/com/elovirta/dita/markdown/renderer/MapRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/MapRenderer.java
@@ -59,6 +59,7 @@ public class MapRenderer extends AbstractRenderer {
     //            .add(ATTRIBUTE_NAME_DOMAINS, "(topic hi-d) (topic ut-d) (topic indexing-d) (topic hazard-d) (topic abbrev-d) (topic pr-d) (topic sw-d) (topic ui-d)")
     .build();
   private static final Attributes TOPICREF_ATTS = buildAtts(MAP_TOPICREF);
+  private static final Attributes TOPICHEAD_ATTS = buildAtts(MAPGROUP_D_TOPICHEAD);
   private static final Attributes TOPICMETA_ATTS = buildAtts(MAP_TOPICMETA);
   private static final Attributes RELTABLE_ATTS = new AttributesBuilder()
     .add(ATTRIBUTE_NAME_CLASS, MAP_RELTABLE.toString())
@@ -411,36 +412,55 @@ public class MapRenderer extends AbstractRenderer {
   }
 
   private void render(final ListItem node, final NodeRendererContext context, final SaxWriter html) {
-    final AttributesBuilder atts = new AttributesBuilder(TOPICREF_ATTS);
-
     final Paragraph paragraph = (Paragraph) node.getChildOfType(Paragraph.class);
     final Link link = paragraph != null ? (Link) paragraph.getChildOfType(Link.class) : null;
-    if (link != null) {
-      atts.addAll(getLinkAttributes(link.getUrl().toString(), TOPICREF_ATTS).build());
-      final String text = link.getText().toString();
-      if (!text.isEmpty()) {
-        atts.add("navtitle", text);
-      }
-    }
     final LinkRef linkRef = paragraph != null ? (LinkRef) paragraph.getChildOfType(LinkRef.class) : null;
-    if (linkRef != null) {
-      final String text = linkRef.getText().toString();
-      final String key = linkRef.getReference() != null ? linkRef.getReference().toString() : text;
-      final Reference refNode = linkRef.getReferenceNode(linkRef.getDocument());
-      if (refNode == null) { // "fake" reference link
-        atts.add(ATTRIBUTE_NAME_KEYREF, key);
-        if (!text.isBlank()) {
-          atts.add("navtitle", text);
-        }
-      } else {
-        atts.addAll(getLinkAttributes(refNode.getUrl().toString(), TOPICREF_ATTS).build());
-        atts.add(ATTRIBUTE_NAME_KEYREF, refNode.getReference().toString());
-        if (!refNode.getTitle().toString().isEmpty()) {
-          atts.add("navtitle", refNode.getTitle().toString());
-        } else if (text != null && !text.isBlank()) {
+    final DitaClass name;
+    final AttributesBuilder atts;
+    if (link != null || linkRef != null) {
+      name = MAP_TOPICREF;
+      atts = new AttributesBuilder(TOPICREF_ATTS);
+      if (link != null) {
+        atts.addAll(getLinkAttributes(link.getUrl().toString(), TOPICREF_ATTS).build());
+        final String text = link.getText().toString();
+        if (!text.isEmpty()) {
           atts.add("navtitle", text);
         }
       }
+      if (linkRef != null) {
+        final String text = linkRef.getText().toString();
+        final String key = linkRef.getReference() != null ? linkRef.getReference().toString() : text;
+        final Reference refNode = linkRef.getReferenceNode(linkRef.getDocument());
+        if (refNode == null) { // "fake" reference link
+          atts.add(ATTRIBUTE_NAME_KEYREF, key);
+          if (!text.isBlank()) {
+            atts.add("navtitle", text);
+          }
+        } else {
+          atts.addAll(getLinkAttributes(refNode.getUrl().toString(), TOPICREF_ATTS).build());
+          atts.add(ATTRIBUTE_NAME_KEYREF, refNode.getReference().toString());
+          if (!refNode.getTitle().toString().isEmpty()) {
+            atts.add("navtitle", refNode.getTitle().toString());
+          } else if (text != null && !text.isBlank()) {
+            atts.add("navtitle", text);
+          }
+        }
+      }
+    } else {
+      name = MAPGROUP_D_TOPICHEAD;
+      atts = new AttributesBuilder(TOPICHEAD_ATTS);
+      final StringBuilder buf = new StringBuilder();
+      Node child = paragraph.getFirstChild();
+      while (child != null) {
+        Node next = child.getNext();
+        if (child instanceof Text) {
+          buf.append(child.getChars());
+        } else if (child instanceof BulletList || child instanceof OrderedList) {
+          break;
+        }
+        child = next;
+      }
+      atts.add("navtitle", buf.toString());
     }
 
     if (node instanceof OrderedListItem) {
@@ -449,7 +469,7 @@ public class MapRenderer extends AbstractRenderer {
       }
     }
 
-    html.startElement(node, MAP_TOPICREF, getInlineAttributes(node, atts.build()));
+    html.startElement(node, name, getInlineAttributes(node, atts.build()));
     Node child = node.getFirstChild();
     while (child != null) {
       Node next = child.getNext();

--- a/src/test/java/com/elovirta/dita/markdown/MDitamapReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MDitamapReaderTest.java
@@ -25,7 +25,14 @@ public class MDitamapReaderTest extends AbstractReaderTest {
 
   @ParameterizedTest
   @ValueSource(
-    strings = { "map/map.md", "map/map_ol.md", "map/map_title.md", "map/map_without_title.md", "map/map_yaml.md" }
+    strings = {
+      "map/map.md",
+      "map/map_ol.md",
+      "map/map_title.md",
+      "map/map_topichead.md",
+      "map/map_without_title.md",
+      "map/map_yaml.md",
+    }
   )
   public void test_map(String file) throws Exception {
     run(file);

--- a/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
+++ b/src/test/java/com/elovirta/dita/markdown/MarkdownReaderTest.java
@@ -104,6 +104,7 @@ public class MarkdownReaderTest extends AbstractReaderTest {
       "map/map_ol.md",
       "map/map_reltable.md",
       "map/map_title.md",
+      "map/map_topichead.md",
       "map/map_without_title.md",
       "map/map_yaml.md",
     }

--- a/src/test/resources/dita/map/map_topichead.dita
+++ b/src/test/resources/dita/map/map_topichead.dita
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " ditaarch:DITAArchVersion="2.0"
+     id="title"
+     specializations="@props/audience @props/deliveryTarget @props/otherprops @props/platform @props/product">
+  <title class="- topic/title ">Title</title>
+  <topicmeta class="- map/topicmeta "/>
+  <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-1.md" navtitle="1">
+    <topichead class="+ map/topicref mapgroup-d/topichead " navtitle="Topic head">
+      <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-1-a-1.md"
+                navtitle="1.A.1"/>
+    </topichead>
+  </topicref>
+  <topichead class="+ map/topicref mapgroup-d/topichead " collection-type="sequence" navtitle="Topic head">
+    <topicref class="- map/topicref " format="markdown" href="topic-2-a.md" navtitle="2.A">
+      <topichead class="+ map/topicref mapgroup-d/topichead " collection-type="sequence" navtitle="Topic head"/>
+    </topicref>
+  </topichead>
+  <topicref class="- map/topicref " format="markdown" href="topic-a.md" navtitle="A">
+    <topichead class="+ map/topicref mapgroup-d/topichead " collection-type="sequence" navtitle="Topic head">
+      <topicref class="- map/topicref " format="markdown" href="topic-a-1-a.md" navtitle="A.1.A"/>
+    </topichead>
+  </topicref>
+  <topichead class="+ map/topicref mapgroup-d/topichead " navtitle="Topic head">
+    <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-b-1.md" navtitle="B.1">
+      <topichead class="+ map/topicref mapgroup-d/topichead " navtitle="Topic head"/>
+    </topicref>
+  </topichead>
+</map>

--- a/src/test/resources/markdown/map/map_topichead.md
+++ b/src/test/resources/markdown/map/map_topichead.md
@@ -1,0 +1,18 @@
+---
+$schema: urn:oasis:names:tc:dita:xsd:map.xsd
+---
+
+# Title
+
+1. [1](topic-1.md)
+    * Topic head
+        1.  [1.A.1](topic-1-a-1.md)
+2. Topic head
+    * [2.A](topic-2-a.md)
+        1.  Topic head
+* [A](topic-a.md)
+    1.  Topic head
+        * [A.1.A](topic-a-1-a.md)
+* Topic head
+    1. [B.1](topic-b-1.md)
+        * Topic head

--- a/src/test/resources/mdita/map/map_topichead.md
+++ b/src/test/resources/mdita/map/map_topichead.md
@@ -1,0 +1,14 @@
+# Title
+
+1. [1](topic-1.md)
+    * Topic head
+        1.  [1.A.1](topic-1-a-1.md)
+2. Topic head
+    * [2.A](topic-2-a.md)
+        1.  Topic head
+* [A](topic-a.md)
+    1.  Topic head
+        * [A.1.A](topic-a-1-a.md)
+* Topic head
+    1. [B.1](topic-b-1.md)
+        * Topic head

--- a/src/test/resources/xdita/map/map_topichead.dita
+++ b/src/test/resources/xdita/map/map_topichead.dita
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " ditaarch:DITAArchVersion="2.0"
+     id="title" specializations="">
+  <title class="- topic/title ">Title</title>
+  <topicref class="- map/topicref " format="markdown" href="topic-1.md" navtitle="1">
+    <topicref class="- map/topicref " navtitle="Topic head">
+      <topicref class="- map/topicref " format="markdown" href="topic-1-a-1.md" navtitle="1.A.1"/>
+    </topicref>
+  </topicref>
+  <topicref class="- map/topicref " navtitle="Topic head">
+    <topicref class="- map/topicref " format="markdown" href="topic-2-a.md" navtitle="2.A">
+      <topicref class="- map/topicref " navtitle="Topic head"/>
+    </topicref>
+  </topicref>
+  <topicref class="- map/topicref " format="markdown" href="topic-a.md" navtitle="A">
+    <topicref class="- map/topicref " navtitle="Topic head">
+      <topicref class="- map/topicref " format="markdown" href="topic-a-1-a.md" navtitle="A.1.A"/>
+    </topicref>
+  </topicref>
+  <topicref class="- map/topicref " navtitle="Topic head">
+    <topicref class="- map/topicref " format="markdown" href="topic-b-1.md" navtitle="B.1">
+      <topicref class="- map/topicref " navtitle="Topic head"/>
+    </topicref>
+  </topicref>
+</map>


### PR DESCRIPTION
In Markdown maps, treat list items without a link as `<topichead>` elements. In MDITA maps only output `<topicref>`.