### PR TITLE
Pass supported formats as property

### DIFF
--- a/src/main/java/com/elovirta/dita/html/HDitaReader.java
+++ b/src/main/java/com/elovirta/dita/html/HDitaReader.java
@@ -1,11 +1,13 @@
 package com.elovirta.dita.html;
 
+import com.vladsch.flexmark.util.data.DataSet;
+
 /**
  * XMLReader implementation for HDITA.
  */
 public class HDitaReader extends HtmlReader {
 
   public HDitaReader() {
-    super("hdita2dita.xsl");
+    super(new DataSet(), "hdita2dita.xsl");
   }
 }

--- a/src/main/java/com/elovirta/dita/html/HtmlReader.java
+++ b/src/main/java/com/elovirta/dita/html/HtmlReader.java
@@ -1,7 +1,10 @@
 package com.elovirta.dita.html;
 
+import static com.elovirta.dita.markdown.MarkdownReader.FORMATS;
+
 import com.elovirta.dita.utils.ClasspathURIResolver;
 import com.google.common.collect.Lists;
+import com.vladsch.flexmark.util.data.DataSet;
 import java.io.IOException;
 import java.util.Arrays;
 import javax.xml.transform.TransformerConfigurationException;
@@ -23,11 +26,7 @@ public class HtmlReader implements XMLReader {
   private final HtmlParser parser;
   private final SAXResult result;
 
-  public HtmlReader() {
-    this("html2dita.xsl");
-  }
-
-  public HtmlReader(final String... stylesheets) {
+  public HtmlReader(DataSet options, final String... stylesheets) {
     parser = new HtmlParser();
     parser.setDoctypeExpectation(DoctypeExpectation.AUTO);
     parser.setHeuristics(Heuristics.ICU);
@@ -44,6 +43,7 @@ public class HtmlReader implements XMLReader {
           "classpath:///" + stylesheet
         );
         transformerHandler = tf.newTransformerHandler(src);
+        transformerHandler.getTransformer().setParameter("formats", String.join(",", FORMATS.get(options)));
         transformerHandler.setResult(res);
         res = new SAXResult(transformerHandler);
       }

--- a/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
+++ b/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
@@ -18,6 +18,7 @@ import com.vladsch.flexmark.ext.superscript.SuperscriptExtension;
 import com.vladsch.flexmark.ext.tables.TablesExtension;
 import com.vladsch.flexmark.ext.yaml.front.matter.YamlFrontMatterExtension;
 import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.ast.KeepType;
 import com.vladsch.flexmark.util.data.DataKey;
 import com.vladsch.flexmark.util.data.DataSet;
 import com.vladsch.flexmark.util.data.MutableDataSet;
@@ -40,6 +41,9 @@ public class MarkdownReader implements XMLReader {
 
   private static final Pattern schemaPattern = Pattern.compile("^---[\r\n]+\\$schema: +(.+?)[\r\n]");
   private static final ServiceLoader<SchemaProvider> schemaLoader = ServiceLoader.load(SchemaProvider.class);
+
+  final public static DataKey<Collection<String>> FORMATS = new DataKey<>("FORMATS", List.of("markdown", "md"));
+  final public static DataKey<Boolean> PROCESSING_MODE = new DataKey<>("PROCESSING_MODE", false);
 
   /**
    * Supported features mapped to options.
@@ -188,8 +192,17 @@ public class MarkdownReader implements XMLReader {
   }
 
   @Override
-  public void setProperty(String name, Object value) throws SAXNotRecognizedException, SAXNotSupportedException {
-    // NOOP
+  public void setProperty(String name, Object value) throws SAXNotRecognizedException {
+    switch (name) {
+      case "https://dita-ot.org/property/formats":
+        options.set(FORMATS, (Collection<String>) value);
+        break;
+      case "https://dita-ot.org/property/processing-mode":
+        options.set(PROCESSING_MODE, "strict".equals(value));
+        break;
+      default:
+        throw new SAXNotRecognizedException(String.format("Property %s not supported", name));
+    }
   }
 
   @Override

--- a/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
+++ b/src/main/java/com/elovirta/dita/markdown/MarkdownReader.java
@@ -42,8 +42,8 @@ public class MarkdownReader implements XMLReader {
   private static final Pattern schemaPattern = Pattern.compile("^---[\r\n]+\\$schema: +(.+?)[\r\n]");
   private static final ServiceLoader<SchemaProvider> schemaLoader = ServiceLoader.load(SchemaProvider.class);
 
-  final public static DataKey<Collection<String>> FORMATS = new DataKey<>("FORMATS", List.of("markdown", "md"));
-  final public static DataKey<Boolean> PROCESSING_MODE = new DataKey<>("PROCESSING_MODE", false);
+  public static final DataKey<Collection<String>> FORMATS = new DataKey<>("FORMATS", List.of("markdown", "md"));
+  public static final DataKey<Boolean> PROCESSING_MODE = new DataKey<>("PROCESSING_MODE", false);
 
   /**
    * Supported features mapped to options.

--- a/src/main/java/com/elovirta/dita/markdown/renderer/AbstractRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/AbstractRenderer.java
@@ -3,6 +3,7 @@
  */
 package com.elovirta.dita.markdown.renderer;
 
+import static com.elovirta.dita.markdown.MarkdownReader.FORMATS;
 import static com.elovirta.dita.markdown.MetadataSerializerImpl.buildAtts;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.URLUtils.toURI;
@@ -27,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -61,6 +63,7 @@ public abstract class AbstractRenderer {
   protected final boolean mditaCoreProfile;
   protected final Supplier<SAXTransformerFactory> transformerFactorySupplier;
   protected final Supplier<Templates> templatesSupplier;
+  protected final Collection<String> formats;
 
   public AbstractRenderer(DataHolder options) {
     mditaExtendedProfile = DitaRenderer.MDITA_EXTENDED_PROFILE.getFrom(options);
@@ -83,6 +86,7 @@ public abstract class AbstractRenderer {
           throw new RuntimeException(e);
         }
       })::get;
+    formats = options.get(FORMATS);
   }
 
   /**
@@ -216,14 +220,12 @@ public abstract class AbstractRenderer {
           case "xml":
             format = null;
             break;
-          // Markdown is converted to DITA
-          case "md":
-          case "markdown":
-            format = "markdown";
-            break;
           default:
-            format = !ext.isEmpty() ? ext : "html";
-            break;
+            if (formats.contains(ext)) {
+              format = ext;
+            } else {
+              format = !ext.isEmpty() ? ext : "html";
+            }
         }
       }
       if (uri.getScheme() != null && uri.getScheme().equals("mailto")) {

--- a/src/main/java/com/elovirta/dita/markdown/renderer/AbstractRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/AbstractRenderer.java
@@ -86,7 +86,7 @@ public abstract class AbstractRenderer {
           throw new RuntimeException(e);
         }
       })::get;
-    formats = options.get(FORMATS);
+    formats = FORMATS.get(options);
   }
 
   /**

--- a/src/main/java/com/elovirta/dita/markdown/renderer/MapRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/MapRenderer.java
@@ -3,6 +3,7 @@
  */
 package com.elovirta.dita.markdown.renderer;
 
+import static com.elovirta.dita.markdown.MarkdownReader.FORMATS;
 import static com.elovirta.dita.markdown.MetadataSerializerImpl.buildAtts;
 import static org.dita.dost.util.Constants.*;
 import static org.dita.dost.util.XMLUtils.AttributesBuilder;
@@ -310,6 +311,7 @@ public class MapRenderer extends AbstractRenderer {
     } catch (final TransformerConfigurationException e) {
       throw new RuntimeException(e);
     }
+    h.getTransformer().setParameter("formats", String.join(",", formats));
     h.setResult(new SAXResult(fragmentFilter));
     final HtmlParser parser = new HtmlParser();
     parser.setContentHandler(h);
@@ -393,6 +395,7 @@ public class MapRenderer extends AbstractRenderer {
     } catch (final TransformerConfigurationException e) {
       throw new RuntimeException(e);
     }
+    h.getTransformer().setParameter("formats", String.join(",", formats));
     final HtmlParser parser = new HtmlParser(XmlViolationPolicy.ALLOW);
     parser.setContentHandler(h);
     html.setLocation(node);

--- a/src/main/java/com/elovirta/dita/markdown/renderer/TopicRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/TopicRenderer.java
@@ -683,6 +683,7 @@ public class TopicRenderer extends AbstractRenderer {
     } catch (final TransformerConfigurationException e) {
       throw new RuntimeException(e);
     }
+    h.getTransformer().setParameter("formats", String.join(",", formats));
     h.setResult(new SAXResult(fragmentFilter));
     final HtmlParser parser = new HtmlParser();
     parser.setContentHandler(h);
@@ -766,6 +767,7 @@ public class TopicRenderer extends AbstractRenderer {
     } catch (final TransformerConfigurationException e) {
       throw new RuntimeException(e);
     }
+    h.getTransformer().setParameter("formats", String.join(",", formats));
     final HtmlParser parser = new HtmlParser(XmlViolationPolicy.ALLOW);
     parser.setContentHandler(h);
     html.setLocation(node);

--- a/src/test/java/com/elovirta/dita/html/HtmlReaderTest.java
+++ b/src/test/java/com/elovirta/dita/html/HtmlReaderTest.java
@@ -1,13 +1,14 @@
 package com.elovirta.dita.html;
 
 import com.elovirta.dita.utils.AbstractReaderTest;
+import com.vladsch.flexmark.util.data.DataSet;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.xml.sax.XMLReader;
 
 public class HtmlReaderTest extends AbstractReaderTest {
 
-  private XMLReader r = new HtmlReader();
+  private XMLReader r = new HtmlReader(new DataSet(), "html2dita.xsl");
 
   @Override
   public XMLReader getReader() {

--- a/src/test/java/com/elovirta/dita/utils/AbstractReaderTest.java
+++ b/src/test/java/com/elovirta/dita/utils/AbstractReaderTest.java
@@ -26,6 +26,7 @@ import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.*;
 import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.diff.DefaultComparisonFormatter;
 import org.xmlunit.diff.Diff;
 
 public abstract class AbstractReaderTest {
@@ -89,6 +90,9 @@ public abstract class AbstractReaderTest {
         .normalizeWhitespace()
         .checkForIdentical()
         .build();
+      if (diff.hasDifferences()) {
+        System.err.println(diff.fullDescription(new DefaultComparisonFormatter()));
+      }
       assertFalse(diff.hasDifferences());
     } catch (AssertionFailedError e) {
       //      transformerFactory.newTransformer().transform(new DOMSource(act), new StreamResult(System.out));

--- a/src/test/resources/dita/keys.dita
+++ b/src/test/resources/dita/keys.dita
@@ -5,10 +5,10 @@
      id="keys">
   <title class="- topic/title ">Keys</title>
   <body class="- topic/body ">
-    <p class="- topic/p ">This is <xref class="- topic/xref " href="test.md" format="markdown">an example</xref> reference-style link.</p>
-    <p class="- topic/p ">This is <xref class="- topic/xref " href="test.md" format="markdown">key-a</xref> reference-style link.</p>
-    <p class="- topic/p ">This is <xref class="- topic/xref " href="test.md" format="markdown">Markdown</xref> reference-style link.</p>
-    <p class="- topic/p ">This is <xref class="- topic/xref " href="test.md" format="markdown">Markdown</xref> reference-style link.</p>
+    <p class="- topic/p ">This is <xref class="- topic/xref " href="test.md" format="md">an example</xref> reference-style link.</p>
+    <p class="- topic/p ">This is <xref class="- topic/xref " href="test.md" format="md">key-a</xref> reference-style link.</p>
+    <p class="- topic/p ">This is <xref class="- topic/xref " href="test.md" format="md">Markdown</xref> reference-style link.</p>
+    <p class="- topic/p ">This is <xref class="- topic/xref " href="test.md" format="md">Markdown</xref> reference-style link.</p>
     <p class="- topic/p ">This is <xref class="- topic/xref " keyref="key-missing">an example</xref> reference-style link.</p>
     <p class="- topic/p ">This is <xref class="- topic/xref " keyref="key-missing"/> reference-style link.</p>
   </body>

--- a/src/test/resources/dita/link.dita
+++ b/src/test/resources/dita/link.dita
@@ -4,10 +4,10 @@
   <title class="- topic/title ">Links</title>
   <body class="- topic/body ">
     <p class="- topic/p ">
-      <xref class="- topic/xref " href="concept.md" format="markdown">Markdown</xref>
+      <xref class="- topic/xref " href="concept.md" format="md">Markdown</xref>
     </p>
     <p class="- topic/p ">
-      <xref class="- topic/xref " href="concept.md#id" format="markdown">Markdown with fragment</xref>
+      <xref class="- topic/xref " href="concept.md#id" format="md">Markdown with fragment</xref>
     </p>
     <p class="- topic/p ">
       <xref class="- topic/xref " href="second.html?pos=3" format="html">Something with query</xref>
@@ -26,7 +26,7 @@
         scope="external">External</xref>
     </p>
     <p class="- topic/p ">
-      <xref class="- topic/xref " href="concept.md" format="markdown"></xref>
+      <xref class="- topic/xref " href="concept.md" format="md"></xref>
     </p>
     <p class="- topic/p ">
       <xref class="- topic/xref " keyref="key"/>

--- a/src/test/resources/dita/map/map.dita
+++ b/src/test/resources/dita/map/map.dita
@@ -4,36 +4,36 @@
      specializations="@props/audience @props/deliveryTarget @props/otherprops @props/platform @props/product">
   <title class="- topic/title ">Title</title>
   <topicmeta class="- map/topicmeta "/>
-  <topicref class="- map/topicref " format="markdown" href="topic-a.md">
+  <topicref class="- map/topicref " format="md" href="topic-a.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">Text <i class="+ topic/ph hi-d/i ">italic</i>
         <b class="+ topic/ph hi-d/b ">bold</b>
         <codeph class="+ topic/ph pr-d/codeph ">code</codeph>
       </navtitle>
     </topicmeta>
-    <topicref class="- map/topicref " format="markdown" href="topic-a-1.md"/>
+    <topicref class="- map/topicref " format="md" href="topic-a-1.md"/>
   </topicref>
-  <topicref class="- map/topicref " format="markdown" href="topic-b.md">
+  <topicref class="- map/topicref " format="md" href="topic-b.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">B</navtitle>
     </topicmeta>
-    <topicref class="- map/topicref " format="markdown" href="topic-b-1.md">
+    <topicref class="- map/topicref " format="md" href="topic-b-1.md">
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">B.1</navtitle>
       </topicmeta>
     </topicref>
   </topicref>
-  <topicref class="- map/topicref " format="markdown" href="test.md" keyref="key-a">
-    <topicref class="- map/topicref " format="markdown" href="test.md" keyref="key-a"/>
-    <topicref class="- map/topicref " format="markdown" href="test.md" keyref="key-a">
+  <topicref class="- map/topicref " format="md" href="test.md" keyref="key-a">
+    <topicref class="- map/topicref " format="md" href="test.md" keyref="key-a"/>
+    <topicref class="- map/topicref " format="md" href="test.md" keyref="key-a">
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">ignored</navtitle>
       </topicmeta>
     </topicref>
   </topicref>
-  <topicref class="- map/topicref " format="markdown" href="test.md" keyref="key-b">
-    <topicref class="- map/topicref " format="markdown" href="test.md" keyref="key-b"/>
-    <topicref class="- map/topicref " format="markdown" href="test.md" keyref="key-b"/>
+  <topicref class="- map/topicref " format="md" href="test.md" keyref="key-b">
+    <topicref class="- map/topicref " format="md" href="test.md" keyref="key-b"/>
+    <topicref class="- map/topicref " format="md" href="test.md" keyref="key-b"/>
   </topicref>
   <topicref class="- map/topicref " keyref="undefined-key">
     <topicref class="- map/topicref " keyref="undefined-key"/>
@@ -43,6 +43,6 @@
       </topicmeta>
     </topicref>
   </topicref>
-  <keydef class="+ map/topicref mapgroup-d/keydef " format="markdown" href="test.md" keys="key-a"/>
-  <keydef class="+ map/topicref mapgroup-d/keydef " format="markdown" href="test.md" keys="key-b"/>
+  <keydef class="+ map/topicref mapgroup-d/keydef " format="md" href="test.md" keys="key-a"/>
+  <keydef class="+ map/topicref mapgroup-d/keydef " format="md" href="test.md" keys="key-b"/>
 </map>

--- a/src/test/resources/dita/map/map_ol.dita
+++ b/src/test/resources/dita/map/map_ol.dita
@@ -4,60 +4,60 @@
      specializations="@props/audience @props/deliveryTarget @props/otherprops @props/platform @props/product">
   <title class="- topic/title ">Title</title>
   <topicmeta class="- map/topicmeta "/>
-  <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-1.md">
+  <topicref class="- map/topicref " collection-type="sequence" format="md" href="topic-1.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">1</navtitle>
     </topicmeta>
-    <topicref class="- map/topicref " format="markdown" href="topic-1-a.md">
+    <topicref class="- map/topicref " format="md" href="topic-1-a.md">
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">1.A</navtitle>
       </topicmeta>
-      <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-1-a-1.md">
+      <topicref class="- map/topicref " collection-type="sequence" format="md" href="topic-1-a-1.md">
         <topicmeta class="- map/topicmeta ">
           <navtitle class="- topic/navtitle ">1.A.1</navtitle>
         </topicmeta>
       </topicref>
     </topicref>
   </topicref>
-  <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-2.md">
+  <topicref class="- map/topicref " collection-type="sequence" format="md" href="topic-2.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">2</navtitle>
     </topicmeta>
-    <topicref class="- map/topicref " format="markdown" href="topic-2-a.md">
+    <topicref class="- map/topicref " format="md" href="topic-2-a.md">
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">2.A</navtitle>
       </topicmeta>
-      <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-2-a-1.md">
+      <topicref class="- map/topicref " collection-type="sequence" format="md" href="topic-2-a-1.md">
         <topicmeta class="- map/topicmeta ">
           <navtitle class="- topic/navtitle ">2.A.1</navtitle>
         </topicmeta>
       </topicref>
     </topicref>
   </topicref>
-  <topicref class="- map/topicref " format="markdown" href="topic-a.md">
+  <topicref class="- map/topicref " format="md" href="topic-a.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">A</navtitle>
     </topicmeta>
-    <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-a-1.md">
+    <topicref class="- map/topicref " collection-type="sequence" format="md" href="topic-a-1.md">
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">A.1</navtitle>
       </topicmeta>
-      <topicref class="- map/topicref " format="markdown" href="topic-a-1-a.md">
+      <topicref class="- map/topicref " format="md" href="topic-a-1-a.md">
         <topicmeta class="- map/topicmeta ">
           <navtitle class="- topic/navtitle ">A.1.A</navtitle>
         </topicmeta>
       </topicref>
     </topicref>
   </topicref>
-  <topicref class="- map/topicref " format="markdown" href="topic-b.md">
+  <topicref class="- map/topicref " format="md" href="topic-b.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">B</navtitle>
     </topicmeta>
-    <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-b-1.md">
+    <topicref class="- map/topicref " collection-type="sequence" format="md" href="topic-b-1.md">
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">B.1</navtitle>
       </topicmeta>
-      <topicref class="- map/topicref " format="markdown" href="topic-b-1-a.md">
+      <topicref class="- map/topicref " format="md" href="topic-b-1-a.md">
         <topicmeta class="- map/topicmeta ">
           <navtitle class="- topic/navtitle ">B.1.A</navtitle>
         </topicmeta>

--- a/src/test/resources/dita/map/map_reltable.dita
+++ b/src/test/resources/dita/map/map_reltable.dita
@@ -2,29 +2,29 @@
 <map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " ditaarch:DITAArchVersion="2.0"
      specializations="@props/audience @props/deliveryTarget @props/otherprops @props/platform @props/product">
   <topicmeta class="- map/topicmeta "/>
-  <topicref class="- map/topicref " format="markdown" href="topic-a.md">
+  <topicref class="- map/topicref " format="md" href="topic-a.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">A</navtitle>
     </topicmeta>
   </topicref>
-  <topicref class="- map/topicref " format="markdown" href="topic-b.md">
+  <topicref class="- map/topicref " format="md" href="topic-b.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">B</navtitle>
     </topicmeta>
   </topicref>
-  <topicref class="- map/topicref " format="markdown" href="topic-c.md" keyref="C"/>
-  <topicref class="- map/topicref " format="markdown" href="topic-d.md" keyref="D"/>
+  <topicref class="- map/topicref " format="md" href="topic-c.md" keyref="C"/>
+  <topicref class="- map/topicref " format="md" href="topic-d.md" keyref="D"/>
   <reltable class="- map/reltable " toc="no">
     <relheader class="- map/relheader ">
       <relcolspec class="- map/relcolspec " toc="no">
-        <topicref class="- map/topicref " format="markdown" href="topic-a.md">
+        <topicref class="- map/topicref " format="md" href="topic-a.md">
           <topicmeta class="- map/topicmeta ">
             <navtitle class="- topic/navtitle ">A</navtitle>
           </topicmeta>
         </topicref>
       </relcolspec>
       <relcolspec class="- map/relcolspec " toc="no">
-        <topicref class="- map/topicref " format="markdown" href="topic-c.md">
+        <topicref class="- map/topicref " format="md" href="topic-c.md">
           <topicmeta class="- map/topicmeta ">
             <navtitle class="- topic/navtitle ">C</navtitle>
           </topicmeta>
@@ -33,14 +33,14 @@
     </relheader>
     <relrow class="- map/relrow ">
       <relcell class="- map/relcell ">
-        <topicref class="- map/topicref " format="markdown" href="topic-b.md">
+        <topicref class="- map/topicref " format="md" href="topic-b.md">
           <topicmeta class="- map/topicmeta ">
             <navtitle class="- topic/navtitle ">B</navtitle>
           </topicmeta>
         </topicref>
       </relcell>
       <relcell class="- map/relcell ">
-        <topicref class="- map/topicref " format="markdown" href="topic-d.md">
+        <topicref class="- map/topicref " format="md" href="topic-d.md">
           <topicmeta class="- map/topicmeta ">
             <navtitle class="- topic/navtitle ">D</navtitle>
           </topicmeta>
@@ -48,6 +48,6 @@
       </relcell>
     </relrow>
   </reltable>
-  <keydef class="+ map/topicref mapgroup-d/keydef " format="markdown" href="topic-c.md" keys="C"/>
-  <keydef class="+ map/topicref mapgroup-d/keydef " format="markdown" href="topic-d.md" keys="D"/>
+  <keydef class="+ map/topicref mapgroup-d/keydef " format="md" href="topic-c.md" keys="C"/>
+  <keydef class="+ map/topicref mapgroup-d/keydef " format="md" href="topic-d.md" keys="D"/>
 </map>

--- a/src/test/resources/dita/map/map_title.dita
+++ b/src/test/resources/dita/map/map_title.dita
@@ -11,10 +11,10 @@
     <codeph class="+ topic/ph pr-d/codeph ">code</codeph>
   </title>
   <topicmeta class="- map/topicmeta "/>
-  <topicref class="- map/topicref " format="markdown" href="topic.md">
+  <topicref class="- map/topicref " format="md" href="topic.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">key</navtitle>
     </topicmeta>
   </topicref>
-  <keydef class="+ map/topicref mapgroup-d/keydef " format="markdown" href="topic.md" keys="key"/>
+  <keydef class="+ map/topicref mapgroup-d/keydef " format="md" href="topic.md" keys="key"/>
 </map>

--- a/src/test/resources/dita/map/map_topichead.dita
+++ b/src/test/resources/dita/map/map_topichead.dita
@@ -4,7 +4,7 @@
      specializations="@props/audience @props/deliveryTarget @props/otherprops @props/platform @props/product">
   <title class="- topic/title ">Title</title>
   <topicmeta class="- map/topicmeta "/>
-  <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-1.md">
+  <topicref class="- map/topicref " collection-type="sequence" format="md" href="topic-1.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">1</navtitle>
     </topicmeta>
@@ -15,7 +15,7 @@
           <codeph class="+ topic/ph pr-d/codeph ">code</codeph> head
         </navtitle>
       </topicmeta>
-      <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-1-a-1.md">
+      <topicref class="- map/topicref " collection-type="sequence" format="md" href="topic-1-a-1.md">
         <topicmeta class="- map/topicmeta ">
           <navtitle class="- topic/navtitle ">1.A.1</navtitle>
         </topicmeta>
@@ -26,7 +26,7 @@
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">Topic head</navtitle>
     </topicmeta>
-    <topicref class="- map/topicref " format="markdown" href="topic-2-a.md">
+    <topicref class="- map/topicref " format="md" href="topic-2-a.md">
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">2.A</navtitle>
       </topicmeta>
@@ -37,7 +37,7 @@
       </topichead>
     </topicref>
   </topichead>
-  <topicref class="- map/topicref " format="markdown" href="topic-a.md">
+  <topicref class="- map/topicref " format="md" href="topic-a.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">A</navtitle>
     </topicmeta>
@@ -45,7 +45,7 @@
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">Topic head</navtitle>
       </topicmeta>
-      <topicref class="- map/topicref " format="markdown" href="topic-a-1-a.md">
+      <topicref class="- map/topicref " format="md" href="topic-a-1-a.md">
         <topicmeta class="- map/topicmeta ">
           <navtitle class="- topic/navtitle ">A.1.A</navtitle>
         </topicmeta>
@@ -56,7 +56,7 @@
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">Topic head</navtitle>
     </topicmeta>
-    <topicref class="- map/topicref " collection-type="sequence" format="markdown" href="topic-b-1.md">
+    <topicref class="- map/topicref " collection-type="sequence" format="md" href="topic-b-1.md">
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">B.1</navtitle>
       </topicmeta>

--- a/src/test/resources/dita/map/map_without_title.dita
+++ b/src/test/resources/dita/map/map_without_title.dita
@@ -2,7 +2,7 @@
 <map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " ditaarch:DITAArchVersion="2.0"
      specializations="@props/audience @props/deliveryTarget @props/otherprops @props/platform @props/product">
   <topicmeta class="- map/topicmeta "/>
-  <topicref class="- map/topicref " format="markdown" href="topic-a.md">
+  <topicref class="- map/topicref " format="md" href="topic-a.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">A</navtitle>
     </topicmeta>

--- a/src/test/resources/dita/map/map_yaml.dita
+++ b/src/test/resources/dita/map/map_yaml.dita
@@ -25,7 +25,7 @@
     <data class="- topic/data " name="tags" value="nothingness"/>
     <data class="- topic/data " name="title" value="'This is the title: it contains a colon'"/>
   </topicmeta>
-  <topicref class="- map/topicref " format="markdown" href="topic-a.md">
+  <topicref class="- map/topicref " format="md" href="topic-a.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">A</navtitle>
     </topicmeta>

--- a/src/test/resources/xdita/keys.dita
+++ b/src/test/resources/xdita/keys.dita
@@ -4,14 +4,14 @@
   specializations="(topic hi-d)(topic em-d)"
   id="keys">
   <title class="- topic/title ">Keys</title>
-  <shortdesc class="- topic/shortdesc ">This is <xref class="- topic/xref " format="markdown"
+  <shortdesc class="- topic/shortdesc ">This is <xref class="- topic/xref " format="md"
       href="test.md">an example</xref> reference-style link.</shortdesc>
   <body class="- topic/body ">
-    <p class="- topic/p ">This is <xref class="- topic/xref " format="markdown" href="test.md"
+    <p class="- topic/p ">This is <xref class="- topic/xref " format="md" href="test.md"
         >key-a</xref> reference-style link.</p>
-    <p class="- topic/p ">This is <xref class="- topic/xref " format="markdown" href="test.md"
+    <p class="- topic/p ">This is <xref class="- topic/xref " format="md" href="test.md"
         >Markdown</xref> reference-style link.</p>
-    <p class="- topic/p ">This is <xref class="- topic/xref " format="markdown" href="test.md"
+    <p class="- topic/p ">This is <xref class="- topic/xref " format="md" href="test.md"
         >Markdown</xref> reference-style link.</p>
     <p class="- topic/p ">This is <xref class="- topic/xref " keyref="key-missing">an example</xref>
       reference-style link.</p>

--- a/src/test/resources/xdita/link.dita
+++ b/src/test/resources/xdita/link.dita
@@ -5,11 +5,11 @@
   id="links">
   <title class="- topic/title ">Links</title>
   <shortdesc class="- topic/shortdesc ">
-    <xref class="- topic/xref " format="markdown" href="concept.md">Markdown</xref>
+    <xref class="- topic/xref " format="md" href="concept.md">Markdown</xref>
   </shortdesc>
   <body class="- topic/body ">
     <p class="- topic/p ">
-      <xref class="- topic/xref " href="concept.md#id" format="markdown">Markdown with fragment</xref>
+      <xref class="- topic/xref " href="concept.md#id" format="md">Markdown with fragment</xref>
     </p>
     <p class="- topic/p ">
       <xref class="- topic/xref " href="second.html?pos=3" format="html">Something with query</xref>
@@ -28,7 +28,7 @@
         scope="external">External</xref>
     </p>
     <p class="- topic/p ">
-      <xref class="- topic/xref " href="concept.md" format="markdown"></xref>
+      <xref class="- topic/xref " href="concept.md" format="md"></xref>
     </p>
     <p class="- topic/p ">
       <xref class="- topic/xref " keyref="key"/>

--- a/src/test/resources/xdita/map/map.dita
+++ b/src/test/resources/xdita/map/map.dita
@@ -2,36 +2,36 @@
 <map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " ditaarch:DITAArchVersion="2.0"
      id="title" specializations="">
   <title class="- topic/title ">Title</title>
-  <topicref class="- map/topicref " format="markdown" href="topic-a.md">
+  <topicref class="- map/topicref " format="md" href="topic-a.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">Text <i class="+ topic/ph hi-d/i ">italic</i>
         <b class="+ topic/ph hi-d/b ">bold</b>
         <tt class="+ topic/ph hi-d/tt ">code</tt>
       </navtitle>
     </topicmeta>
-    <topicref class="- map/topicref " format="markdown" href="topic-a-1.md"/>
+    <topicref class="- map/topicref " format="md" href="topic-a-1.md"/>
   </topicref>
-  <topicref class="- map/topicref " format="markdown" href="topic-b.md">
+  <topicref class="- map/topicref " format="md" href="topic-b.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">B</navtitle>
     </topicmeta>
-    <topicref class="- map/topicref " format="markdown" href="topic-b-1.md">
+    <topicref class="- map/topicref " format="md" href="topic-b-1.md">
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">B.1</navtitle>
       </topicmeta>
     </topicref>
   </topicref>
-  <topicref class="- map/topicref " format="markdown" href="test.md" keyref="key-a">
-    <topicref class="- map/topicref " format="markdown" href="test.md" keyref="key-a"/>
-    <topicref class="- map/topicref " format="markdown" href="test.md" keyref="key-a">
+  <topicref class="- map/topicref " format="md" href="test.md" keyref="key-a">
+    <topicref class="- map/topicref " format="md" href="test.md" keyref="key-a"/>
+    <topicref class="- map/topicref " format="md" href="test.md" keyref="key-a">
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">ignored</navtitle>
       </topicmeta>
     </topicref>
   </topicref>
-  <topicref class="- map/topicref " format="markdown" href="test.md" keyref="key-b">
-    <topicref class="- map/topicref " format="markdown" href="test.md" keyref="key-b"/>
-    <topicref class="- map/topicref " format="markdown" href="test.md" keyref="key-b"/>
+  <topicref class="- map/topicref " format="md" href="test.md" keyref="key-b">
+    <topicref class="- map/topicref " format="md" href="test.md" keyref="key-b"/>
+    <topicref class="- map/topicref " format="md" href="test.md" keyref="key-b"/>
   </topicref>
   <topicref class="- map/topicref " keyref="undefined-key">
     <topicref class="- map/topicref " keyref="undefined-key"/>
@@ -41,6 +41,6 @@
       </topicmeta>
     </topicref>
   </topicref>
-  <keydef class="+ map/topicref mapgroup-d/keydef " format="markdown" href="test.md" keys="key-a"/>
-  <keydef class="+ map/topicref mapgroup-d/keydef " format="markdown" href="test.md" keys="key-b"/>
+  <keydef class="+ map/topicref mapgroup-d/keydef " format="md" href="test.md" keys="key-a"/>
+  <keydef class="+ map/topicref mapgroup-d/keydef " format="md" href="test.md" keys="key-b"/>
 </map>

--- a/src/test/resources/xdita/map/map_ol.dita
+++ b/src/test/resources/xdita/map/map_ol.dita
@@ -2,60 +2,60 @@
 <map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " ditaarch:DITAArchVersion="2.0"
      id="title" specializations="">
   <title class="- topic/title ">Title</title>
-  <topicref class="- map/topicref " format="markdown" href="topic-1.md">
+  <topicref class="- map/topicref " format="md" href="topic-1.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">1</navtitle>
     </topicmeta>
-    <topicref class="- map/topicref " format="markdown" href="topic-1-a.md">
+    <topicref class="- map/topicref " format="md" href="topic-1-a.md">
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">1.A</navtitle>
       </topicmeta>
-      <topicref class="- map/topicref " format="markdown" href="topic-1-a-1.md">
+      <topicref class="- map/topicref " format="md" href="topic-1-a-1.md">
         <topicmeta class="- map/topicmeta ">
           <navtitle class="- topic/navtitle ">1.A.1</navtitle>
         </topicmeta>
       </topicref>
     </topicref>
   </topicref>
-  <topicref class="- map/topicref " format="markdown" href="topic-2.md">
+  <topicref class="- map/topicref " format="md" href="topic-2.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">2</navtitle>
     </topicmeta>
-    <topicref class="- map/topicref " format="markdown" href="topic-2-a.md">
+    <topicref class="- map/topicref " format="md" href="topic-2-a.md">
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">2.A</navtitle>
       </topicmeta>
-      <topicref class="- map/topicref " format="markdown" href="topic-2-a-1.md">
+      <topicref class="- map/topicref " format="md" href="topic-2-a-1.md">
         <topicmeta class="- map/topicmeta ">
           <navtitle class="- topic/navtitle ">2.A.1</navtitle>
         </topicmeta>
       </topicref>
     </topicref>
   </topicref>
-  <topicref class="- map/topicref " format="markdown" href="topic-a.md">
+  <topicref class="- map/topicref " format="md" href="topic-a.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">A</navtitle>
     </topicmeta>
-    <topicref class="- map/topicref " format="markdown" href="topic-a-1.md">
+    <topicref class="- map/topicref " format="md" href="topic-a-1.md">
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">A.1</navtitle>
       </topicmeta>
-      <topicref class="- map/topicref " format="markdown" href="topic-a-1-a.md">
+      <topicref class="- map/topicref " format="md" href="topic-a-1-a.md">
         <topicmeta class="- map/topicmeta ">
           <navtitle class="- topic/navtitle ">A.1.A</navtitle>
         </topicmeta>
       </topicref>
     </topicref>
   </topicref>
-  <topicref class="- map/topicref " format="markdown" href="topic-b.md">
+  <topicref class="- map/topicref " format="md" href="topic-b.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">B</navtitle>
     </topicmeta>
-    <topicref class="- map/topicref " format="markdown" href="topic-b-1.md">
+    <topicref class="- map/topicref " format="md" href="topic-b-1.md">
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">B.1</navtitle>
       </topicmeta>
-      <topicref class="- map/topicref " format="markdown" href="topic-b-1-a.md">
+      <topicref class="- map/topicref " format="md" href="topic-b-1-a.md">
         <topicmeta class="- map/topicmeta ">
           <navtitle class="- topic/navtitle ">B.1.A</navtitle>
         </topicmeta>

--- a/src/test/resources/xdita/map/map_title.dita
+++ b/src/test/resources/xdita/map/map_title.dita
@@ -9,10 +9,10 @@
     <b class="+ topic/ph hi-d/b ">bold</b>
     <tt class="+ topic/ph hi-d/tt ">code</tt>
   </title>
-  <topicref class="- map/topicref " format="markdown" href="topic.md">
+  <topicref class="- map/topicref " format="md" href="topic.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">key</navtitle>
     </topicmeta>
   </topicref>
-  <keydef class="+ map/topicref mapgroup-d/keydef " format="markdown" href="topic.md" keys="key"/>
+  <keydef class="+ map/topicref mapgroup-d/keydef " format="md" href="topic.md" keys="key"/>
 </map>

--- a/src/test/resources/xdita/map/map_topichead.dita
+++ b/src/test/resources/xdita/map/map_topichead.dita
@@ -2,7 +2,7 @@
 <map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " ditaarch:DITAArchVersion="2.0"
      id="title" specializations="">
   <title class="- topic/title ">Title</title>
-  <topicref class="- map/topicref " format="markdown" href="topic-1.md">
+  <topicref class="- map/topicref " format="md" href="topic-1.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">1</navtitle>
     </topicmeta>
@@ -13,7 +13,7 @@
           <tt class="+ topic/ph hi-d/tt ">code</tt> head
         </navtitle>
       </topicmeta>
-      <topicref class="- map/topicref " format="markdown" href="topic-1-a-1.md">
+      <topicref class="- map/topicref " format="md" href="topic-1-a-1.md">
         <topicmeta class="- map/topicmeta ">
           <navtitle class="- topic/navtitle ">1.A.1</navtitle>
         </topicmeta>
@@ -24,7 +24,7 @@
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">Topic head</navtitle>
     </topicmeta>
-    <topicref class="- map/topicref " format="markdown" href="topic-2-a.md">
+    <topicref class="- map/topicref " format="md" href="topic-2-a.md">
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">2.A</navtitle>
       </topicmeta>
@@ -35,7 +35,7 @@
       </topicref>
     </topicref>
   </topicref>
-  <topicref class="- map/topicref " format="markdown" href="topic-a.md">
+  <topicref class="- map/topicref " format="md" href="topic-a.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">A</navtitle>
     </topicmeta>
@@ -43,7 +43,7 @@
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">Topic head</navtitle>
       </topicmeta>
-      <topicref class="- map/topicref " format="markdown" href="topic-a-1-a.md">
+      <topicref class="- map/topicref " format="md" href="topic-a-1-a.md">
         <topicmeta class="- map/topicmeta ">
           <navtitle class="- topic/navtitle ">A.1.A</navtitle>
         </topicmeta>
@@ -54,7 +54,7 @@
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">Topic head</navtitle>
     </topicmeta>
-    <topicref class="- map/topicref " format="markdown" href="topic-b-1.md">
+    <topicref class="- map/topicref " format="md" href="topic-b-1.md">
       <topicmeta class="- map/topicmeta ">
         <navtitle class="- topic/navtitle ">B.1</navtitle>
       </topicmeta>

--- a/src/test/resources/xdita/map/map_without_title.dita
+++ b/src/test/resources/xdita/map/map_without_title.dita
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map xmlns:ditaarch="http://dita.oasis-open.org/architecture/2005/" class="- map/map " ditaarch:DITAArchVersion="2.0"
      specializations="">
-  <topicref class="- map/topicref " format="markdown" href="topic-a.md">
+  <topicref class="- map/topicref " format="md" href="topic-a.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">A</navtitle>
     </topicmeta>

--- a/src/test/resources/xdita/map/map_yaml.dita
+++ b/src/test/resources/xdita/map/map_yaml.dita
@@ -25,7 +25,7 @@
     <data class="- topic/data " name="tags" value="nothingness"/>
     <data class="- topic/data " name="title" value="'This is the title: it contains a colon'"/>
   </topicmeta>
-  <topicref class="- map/topicref " format="markdown" href="topic-a.md">
+  <topicref class="- map/topicref " format="md" href="topic-a.md">
     <topicmeta class="- map/topicmeta ">
       <navtitle class="- topic/navtitle ">A</navtitle>
     </topicmeta>


### PR DESCRIPTION
Pass a set of formats that can be parsed into DITA using SAX `setProperty` method.

Only works with DITA-OT 4.1. On older version default to `md` and `markdown`.