### PR TITLE
Add support for codeblock language prefix

### DIFF
--- a/src/main/java/com/elovirta/dita/markdown/DitaRendererOptions.java
+++ b/src/main/java/com/elovirta/dita/markdown/DitaRendererOptions.java
@@ -6,9 +6,11 @@ public class DitaRendererOptions {
 
   public final boolean doNotRenderLinksInDocument;
   public final String noLanguageClass;
+  public final String languageClassPrefix;
 
   public DitaRendererOptions(DataHolder options) {
     doNotRenderLinksInDocument = DitaRenderer.DO_NOT_RENDER_LINKS.get(options);
     noLanguageClass = DitaRenderer.FENCED_CODE_NO_LANGUAGE_CLASS.get(options);
+    languageClassPrefix = DitaRenderer.FENCED_CODE_LANGUAGE_CLASS_PREFIX.get(options);
   }
 }

--- a/src/main/java/com/elovirta/dita/markdown/renderer/TopicRenderer.java
+++ b/src/main/java/com/elovirta/dita/markdown/renderer/TopicRenderer.java
@@ -1293,7 +1293,7 @@ public class TopicRenderer extends AbstractRenderer {
       } else {
         language = info.subSequence(0, space);
       }
-      atts.add("outputclass", /*context.getDitaOptions().languageClassPrefix +*/language.unescape());
+      atts.add("outputclass", context.getDitaOptions().languageClassPrefix + language.unescape());
     } else {
       String noLanguageClass = context.getDitaOptions().noLanguageClass.trim();
       if (!noLanguageClass.isEmpty()) {

--- a/src/main/resources/ast2markdown.xsl
+++ b/src/main/resources/ast2markdown.xsl
@@ -5,6 +5,8 @@
                 exclude-result-prefixes="xs ast"
                 version="2.0">
 
+  <xsl:param name="codeblock-languge-prefix" as="xs:string?" select="'language-'"/>
+
   <xsl:variable name="linefeed" as="xs:string" select="'&#xA;'"/>
 
   <!-- Block -->
@@ -123,11 +125,18 @@
 
   <xsl:template match="codeblock" mode="ast">
     <xsl:param name="indent" tunnel="yes" as="xs:string" select="''"/>
+
+    <xsl:variable name="classes" select="tokenize(normalize-space(@class), '\s+')" as="xs:string*"/>
+
     <xsl:value-of select="$indent"/>
     <xsl:text>```</xsl:text>
     <xsl:choose>
-      <xsl:when test="empty(@id) and @class and not(contains(@class, ' '))">
-        <xsl:value-of select="@class"/>
+      <xsl:when test="exists($codeblock-languge-prefix) and string-length($codeblock-languge-prefix) ne 0 and
+                      count($classes) eq 1 and starts-with($classes, $codeblock-languge-prefix)">
+        <xsl:value-of select="substring-after($classes, $codeblock-languge-prefix)"/>
+      </xsl:when>
+      <xsl:when test="empty(@id) and count($classes) eq 1">
+        <xsl:value-of select="$classes"/>
       </xsl:when>
       <xsl:otherwise>
         <xsl:call-template name="ast-attibutes"/>

--- a/src/test/resources/ast/codeblock.xml
+++ b/src/test/resources/ast/codeblock.xml
@@ -11,6 +11,10 @@
       <para>Fenced block:</para>
       <codeblock xml:space="preserve" class="scala" id="codeblock__foreach-example">items.foreach(println)
 </codeblock>
+      <para>Syntax highlighting:</para>
+      <codeblock xml:space="preserve" class="language-js">function add(a, b) {
+  return a + b;
+}</codeblock>
     </div>
   </div>
 </pandoc>

--- a/src/test/resources/dita/codeblock.dita
+++ b/src/test/resources/dita/codeblock.dita
@@ -11,5 +11,9 @@
     <p class="- topic/p ">Fenced block:</p>
     <codeblock class="+ topic/pre pr-d/codeblock " id="foreach-example" outputclass="scala" xml:space="preserve">items.foreach(println)
 </codeblock>
+    <p class="- topic/p ">Syntax highlighting:</p>
+    <codeblock class="+ topic/pre pr-d/codeblock " outputclass="language-js" xml:space="preserve">function add(a, b) {
+  return a + b;
+}</codeblock>
   </body>
 </topic>

--- a/src/test/resources/hdita/codeblock.html
+++ b/src/test/resources/hdita/codeblock.html
@@ -8,4 +8,8 @@
       println(i)</tt></pre>
   <p>Fenced block:</p>
   <pre id="foreach-example" class="scala"><tt>items.foreach(println)</tt></pre>
+  <p>Syntax highlighting:</p>
+  <pre class="language-js"><tt>function add(a, b) {
+  return a + b;
+}</tt></pre>
 </article>

--- a/src/test/resources/html/codeblock.html
+++ b/src/test/resources/html/codeblock.html
@@ -8,4 +8,8 @@
       println(i)</code></pre>
   <p>Fenced block:</p>
   <pre id="foreach-example" class="scala"><code>items.foreach(println)</code></pre>
+  <p>Syntax highlighting:</p>
+  <pre class="language-js"><code>function add(a, b) {
+  return a + b;
+}</code></pre>
 </article>

--- a/src/test/resources/markdown/codeblock.md
+++ b/src/test/resources/markdown/codeblock.md
@@ -10,3 +10,11 @@ Fenced block:
 ```{.scala #foreach-example}
 items.foreach(println)
 ```
+
+Syntax highlighting:
+
+```js
+function add(a, b) {
+  return a + b;
+}
+```

--- a/src/test/resources/output/ast/codeblock.xml
+++ b/src/test/resources/output/ast/codeblock.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?><pandoc><div><header id="codeblock" level="1">Codeblock</header><div><para>Code example on <code>for</code> loop:</para><codeblock xml:space="preserve">for i in items:
     println(i)
 </codeblock><para>Fenced block:</para><codeblock class="scala" id="foreach-example" xml:space="preserve">items.foreach(println)
-</codeblock></div></div></pandoc>
+</codeblock><para>Syntax highlighting:</para><codeblock xml:space="preserve" class="language-js">function add(a, b) {
+  return a + b;
+}</codeblock></div></div></pandoc>

--- a/src/test/resources/output/markdown/codeblock.md
+++ b/src/test/resources/output/markdown/codeblock.md
@@ -15,3 +15,11 @@ items.foreach(println)
 
 ```
 
+Syntax highlighting:
+
+```js
+function add(a, b) {
+  return a + b;
+}
+```
+

--- a/src/test/resources/xdita/codeblock.dita
+++ b/src/test/resources/xdita/codeblock.dita
@@ -10,5 +10,9 @@
     println(i)</tt></pre>
     <p class="- topic/p ">Fenced block:</p>
     <pre class="- topic/pre " id="foreach-example" outputclass="scala" xml:space="preserve"><tt class="+ topic/ph hi-d/tt ">items.foreach(println)</tt></pre>
+    <p class="- topic/p ">Syntax highlighting:</p>
+    <pre class="- topic/pre " outputclass="language-js" xml:space="preserve"><tt class="+ topic/ph hi-d/tt ">function add(a, b) {
+  return a + b;
+}</tt></pre>
   </body>
 </topic>


### PR DESCRIPTION
Add support for codeblock language prefix. By default the prefix is `language-`.