### PR TITLE
impl fn templates in hdita2dita  

### DIFF
--- a/src/main/resources/hdita2dita-common.xsl
+++ b/src/main/resources/hdita2dita-common.xsl
@@ -588,34 +588,44 @@
   </xsl:template>
 
   <!-- Footnote -->
+  <!--ex. <div data-class="fn" id="id">...</div>-->
   <xsl:template match="div[@data-class = 'fn'][exists(@id)][1]" priority="3">
-    <xsl:variable name="siblings" 
-      select="self::div[@data-class = 'fn'][exists(@id)] | following-sibling::div[contains(@data-class, 'fn')][exists(@id)]"/>
+    <xsl:variable name="siblings" as="element()*"
+      select="self::div[@data-class = 'fn'][exists(@id)] | following-sibling::div[@data-class = 'fn'][exists(@id)]"/>
+    <!--if parent is not div, wrap fn with div-->
+    <xsl:variable name="has-parent-div" as="xs:boolean" select="exists(parent::div)"/>
     <xsl:variable name="fns" as="element()+" >
-      <xsl:iterate select="$siblings">
-        <fn>
+    <xsl:for-each select="$siblings">
+        <fn xmlns="">
           <xsl:apply-templates select=". except text()" mode="class"/>
           <xsl:apply-templates select="(@* except @data-class) | node()"/>
         </fn>
-        <xsl:next-iteration/>
-      </xsl:iterate>  
+      </xsl:for-each>
     </xsl:variable>
     <!-- sanitize fn position -->
     <xsl:choose>
-      <xsl:when test="exists(parent::div)">
+      <xsl:when test="$has-parent-div">
         <xsl:copy-of select="$fns"/>
       </xsl:when>
       <xsl:otherwise>
-        <div class="- topic/div ">
+        <div class="- topic/div " xmlns="">
           <xsl:copy-of select="$fns"/>
         </div>  
       </xsl:otherwise> 
     </xsl:choose>
   </xsl:template>
 
+  <!-- They are applied by div[@data-class = 'fn'][exists(@id)][1]'s 
+      xsl:for-each. So we don't need to do nothing their own templates.
+  -->
   <xsl:template match="div[@data-class = 'fn'][exists(@id)][position() gt 1]"
     priority="3"/>
-
+  <!-- <div data-class="fn"> has to be called by cross-ref.
+        If it has no id, then we ignore it.-->
+  <xsl:template match="div[@data-class = 'fn'][empty(@id)]"
+    priority="1"/>
+  
+  <!-- <span data-class="fn">...</span> -->
   <xsl:template match="span[@data-class = 'fn']" priority="3">
     <fn>
       <xsl:apply-templates select=". except text()" mode="class"/>

--- a/src/main/resources/hdita2dita-common.xsl
+++ b/src/main/resources/hdita2dita-common.xsl
@@ -587,6 +587,46 @@
     <xsl:attribute name="class">- topic/fallback </xsl:attribute>
   </xsl:template>
 
+  <!-- Footnote -->
+  <xsl:template match="div[@data-class = 'fn'][exists(@id)][1]" priority="3">
+    <xsl:variable name="siblings" 
+      select="self::div[@data-class = 'fn'][exists(@id)] | following-sibling::div[contains(@data-class, 'fn')][exists(@id)]"/>
+    <xsl:variable name="fns" as="element()+" >
+      <xsl:iterate select="$siblings">
+        <fn>
+          <xsl:apply-templates select=". except text()" mode="class"/>
+          <xsl:apply-templates select="(@* except @data-class) | node()"/>
+        </fn>
+        <xsl:next-iteration/>
+      </xsl:iterate>  
+    </xsl:variable>
+    <!-- sanitize fn position -->
+    <xsl:choose>
+      <xsl:when test="exists(parent::div)">
+        <xsl:copy-of select="$fns"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <div class="- topic/div ">
+          <xsl:copy-of select="$fns"/>
+        </div>  
+      </xsl:otherwise> 
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="div[@data-class = 'fn'][exists(@id)][position() gt 1]"
+    priority="3"/>
+
+  <xsl:template match="span[@data-class = 'fn']" priority="3">
+    <fn>
+      <xsl:apply-templates select=". except text()" mode="class"/>
+      <xsl:apply-templates select="(@* except @data-class) | node()"/>
+    </fn>
+  </xsl:template>
+ 
+  <xsl:template match="*[@data-class = 'fn']" mode="class">
+    <xsl:attribute name="class">- topic/fn </xsl:attribute> 
+  </xsl:template>
+
 <!--  <xsl:template match="controls" mode="class">-->
 <!--    <xsl:attribute name="class">- topic/controls </xsl:attribute>-->
 <!--    <xsl:attribute name="name" select="local-name()"/>-->


### PR DESCRIPTION
This pull request introduces a new feature for handling footnotes in the `hdita2dita-common.xsl` file.
It adds templates to process `div` and `span` elements with the `data-class="fn"` attribute.

* **New Template for `div` with `data-class="fn`**: Added a template to process `div` elements with `data-class="fn"` and an `id` attribute. It wraps footnotes in a `div` if their parent is not a `div`, and sanitizes the position of footnotes.
* **Template for Ignoring Redundant Footnotes**: Added a template to ignore `div` elements with `data-class="fn"` that lack an `id` attribute.
* **New Template for `span` with `data-class="fn`**: Added a template to process `span` elements with `data-class="fn"`, transforming them into `fn` elements.
* **Class Attribute Handling for Footnotes**: Added a mode-specific template to assign the `class` attribute `- topic/fn` to elements with `data-class="fn"`.

---


from

```html
<p>This is a sentence<span data-class="fn">inline footnote </span>.</p>
<p>This is a sentence<a href="#fn2"></a>.</p>

<div data-class="fn" id="fn2" ><p>referred  footnote</p></div>
```

to 

```xml
<p>This is a sentence<fn>inline footnote </fn>.</p>
<p>This is a sentence<xref href="#fn2"></xref>.</p><!--not correct @id format in this PR-->
<div>
<fn  id="fn2" ><p>referred  footnote</p></fn>
</div>
```
